### PR TITLE
REST Alias

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -317,3 +317,18 @@ add_filter('wp_feature_rest_response', function($response, $feature) {
     return $response;
 }, 10, 2);
 ```
+
+## WP REST Aliases
+
+The REST API already shares a lot of the same functionality we are trying to expose in the Feature API. We can leverage this to some extent to avoid duplicating functionality by defining aliases.
+
+If a feature is registered with a `rest_alias` that corresponds to a REST route, then the feature will use any properties of the rest route as its own properties, such as the callback, args, schema, and permissions.
+
+```php
+wp_register_feature("posts", [
+    "id" => "posts",
+    "is_rest_alias" => true,
+    "description" => "Query and get WordPress post objects.",
+	"type" => "resource",
+]);
+```

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,6 @@
     "format": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf --report=summary,source",
     "lint": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --report=summary,source",
     "lint:errors": "@lint -n",
-    "serve": "npx @wp-now/wp-now start --php=7.2"
+    "serve": "npx @wp-now/wp-now start --php=7.2 --port=8881"
   }
 }

--- a/demo/wp-feature-api-demo/includes/demo-features.php
+++ b/demo/wp-feature-api-demo/includes/demo-features.php
@@ -12,7 +12,6 @@
  * @return void
  */
 function wp_feature_api_demo_register_features() {
-	// Register a simple resource feature for getting site information.
 	wp_register_feature(
 		array(
 			'id'          => 'demo/site-info',
@@ -22,69 +21,6 @@ function wp_feature_api_demo_register_features() {
 			'categories'  => array( 'demo', 'site', 'information' ),
 			'callback'    => 'wp_feature_api_demo_site_info_callback',
 			'permissions' => 'administrator',
-		)
-	);
-
-	// Register a tool feature for creating a post.
-	wp_register_feature(
-		array(
-			'id'          => 'demo/create-post',
-			'name'        => __( 'Create Post', 'wp-feature-api-demo' ),
-			'description' => __( 'Create a new post in WordPress.', 'wp-feature-api-demo' ),
-			'type'        => WP_Feature::TYPE_TOOL,
-			'categories'  => array( 'post', 'create' ),
-			'input_schema' => array(
-				'type'       => 'object',
-				'properties' => array(
-					'title'   => array(
-						'type'        => 'string',
-						'description' => __( 'The title of the post.', 'wp-feature-api-demo' ),
-					),
-					'content' => array(
-						'type'        => 'string',
-						'description' => __( 'The content of the post.', 'wp-feature-api-demo' ),
-					),
-					'status'  => array(
-						'type'        => 'string',
-						'description' => __( 'The status of the post.', 'wp-feature-api-demo' ),
-						'default'     => 'draft',
-						'enum'        => array( 'draft', 'publish', 'pending', 'future', 'private' ),
-					),
-				),
-				'required'   => array( 'title', 'content' ),
-			),
-			'output_schema' => array(
-				'type'       => 'object',
-				'properties' => array(
-					'id'     => array(
-						'type'        => 'integer',
-						'description' => __( 'The ID of the created post.', 'wp-feature-api-demo' ),
-					),
-					'url'    => array(
-						'type'        => 'string',
-						'description' => __( 'The URL of the created post.', 'wp-feature-api-demo' ),
-					),
-					'status' => array(
-						'type'        => 'string',
-						'description' => __( 'The status of the created post.', 'wp-feature-api-demo' ),
-					),
-				),
-			),
-			'callback'    => 'wp_feature_api_demo_create_post_callback',
-			'permissions' => 'publish_posts',
-		)
-	);
-
-	// Register a resource feature for retrieving user data.
-	wp_register_feature(
-		array(
-			'id'          => 'demo/current-user',
-			'name'        => __( 'Current User', 'wp-feature-api-demo' ),
-			'description' => __( 'Get information about the current user.', 'wp-feature-api-demo' ),
-			'type'        => WP_Feature::TYPE_RESOURCE,
-			'categories'  => array( 'user', 'information' ),
-			'callback'    => 'wp_feature_api_demo_current_user_callback',
-			'permissions' => 'read',
 		)
 	);
 }
@@ -106,71 +42,9 @@ function wp_feature_api_demo_site_info_callback( $input ) {
 		'timezone'    => wp_timezone_string(),
 		'date_format' => get_option( 'date_format' ),
 		'time_format' => get_option( 'time_format' ),
+		'active_plugins' => get_option( 'active_plugins' ),
+		'active_theme' => get_option( 'stylesheet' ),
 	);
 }
 
-/**
- * Callback for the 'demo/create-post' feature.
- *
- * @since 0.1.0
- * @param array $input The input data containing title, content, and status.
- * @return array Information about the created post.
- */
-function wp_feature_api_demo_create_post_callback( $input ) {
-	$post_data = array(
-		'post_title'   => sanitize_text_field( $input['title'] ),
-		'post_content' => wp_kses_post( $input['content'] ),
-		'post_status'  => isset( $input['status'] ) ? sanitize_key( $input['status'] ) : 'draft',
-		'post_type'    => 'post',
-	);
-
-	$post_id = wp_insert_post( $post_data );
-
-	if ( is_wp_error( $post_id ) ) {
-		return new WP_Error(
-			'post_creation_failed',
-			__( 'Failed to create post.', 'wp-feature-api-demo' ),
-			array( 'status' => 500 )
-		);
-	}
-
-	return array(
-		'id'     => $post_id,
-		'url'    => get_permalink( $post_id ),
-		'status' => get_post_status( $post_id ),
-	);
-}
-
-/**
- * Callback for the 'demo/current-user' feature.
- *
- * @since 0.1.0
- * @param array $input The input data (not used in this case).
- * @return array Current user information.
- */
-function wp_feature_api_demo_current_user_callback( $input ) {
-	$current_user = wp_get_current_user();
-
-	if ( ! $current_user->exists() ) {
-		return new WP_Error(
-			'no_user',
-			__( 'No authenticated user found.', 'wp-feature-api-demo' ),
-			array( 'status' => 401 )
-		);
-	}
-
-	return array(
-		'id'            => $current_user->ID,
-		'username'      => $current_user->user_login,
-		'email'         => $current_user->user_email,
-		'display_name'  => $current_user->display_name,
-		'roles'         => $current_user->roles,
-		'first_name'    => $current_user->first_name,
-		'last_name'     => $current_user->last_name,
-		'registered'    => $current_user->user_registered,
-		'capabilities'  => array_keys( array_filter( $current_user->allcaps ) ),
-	);
-}
-
-// Register demo features.
 add_action( 'init', 'wp_feature_api_demo_register_features' );

--- a/demo/wp-feature-api-demo/wp-feature-api-demo.php
+++ b/demo/wp-feature-api-demo/wp-feature-api-demo.php
@@ -19,10 +19,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! function_exists( 'wp_register_feature' ) ) {
-	add_action( 'admin_notices', 'wp_feature_api_demo_missing_notice' );
-	return;
+/**
+ * Initialize the WordPress Feature API Demo plugin.
+ *
+ * @since 0.1.0
+ * @return void
+ */
+function wp_feature_api_demo_init() {
+	require_once plugin_dir_path( __FILE__ ) . 'includes/demo-features.php';
+
+	if ( ! function_exists( 'wp_register_feature' ) ) {
+		add_action( 'admin_notices', 'wp_feature_api_demo_missing_notice' );
+		return;
+	}
 }
+
+add_action( 'plugins_loaded', 'wp_feature_api_demo_init', 20 );
+
 
 /**
  * Display an admin notice if the WordPress Feature API plugin is not active.
@@ -45,15 +58,3 @@ function wp_feature_api_demo_missing_notice() {
 	</div>
 	<?php
 }
-
-/**
- * Initialize the WordPress Feature API Demo plugin.
- *
- * @since 0.1.0
- * @return void
- */
-function wp_feature_api_demo_init() {
-	require_once plugin_dir_path( __FILE__ ) . 'includes/demo-features.php';
-}
-
-add_action( 'plugins_loaded', 'wp_feature_api_demo_init', 20 );

--- a/includes/class-wp-feature-registry.php
+++ b/includes/class-wp-feature-registry.php
@@ -39,6 +39,14 @@ class WP_Feature_Registry {
 	 */
 	private $features = array();
 
+
+	/**
+	 * @todo: keep track of categories
+	 * this will be important for use in inference using an LLM to narrow down the features by category.
+	 * should categories contain descriptions?
+	 */
+	private $categories = array();
+
 	/**
 	 * Private constructor to prevent direct instantiation.
 	 * Sets the repository to use for the registry.

--- a/includes/class-wp-feature-registry.php
+++ b/includes/class-wp-feature-registry.php
@@ -32,12 +32,12 @@ class WP_Feature_Registry {
 
 	/**
 	 * In-memory cache of feature IDs.
-	 * Features are fetched from the repository when needed.
+	 * Separated by type.
 	 *
 	 * @since 0.1.0
 	 * @var array
 	 */
-	private $feature_ids = array();
+	private $features = array();
 
 	/**
 	 * Private constructor to prevent direct instantiation.
@@ -66,6 +66,7 @@ class WP_Feature_Registry {
 		}
 
 		$this->repository = $repository;
+		$this->cache_clear();
 	}
 
 	/**
@@ -90,21 +91,13 @@ class WP_Feature_Registry {
 	 * @return bool True if the feature was registered, false otherwise.
 	 */
 	public function register( $feature ) {
-		if ( is_array( $feature ) ) {
-			if ( ! isset( $feature['id'] ) ) {
-				return false;
-			}
+		$feature = WP_Feature::make( $feature );
 
-			$feature = new WP_Feature( $feature['id'], $feature );
-		}
-
-		if ( ! $feature instanceof WP_Feature ) {
+		if ( ! $feature ) {
 			return false;
 		}
 
-		$feature_id = $feature->get_id();
-
-		if ( $this->repository->find( $feature_id ) ) {
+		if ( $this->repository->find( $feature ) ) {
 			return false;
 		}
 
@@ -114,8 +107,8 @@ class WP_Feature_Registry {
 			return false;
 		}
 
-		if ( ! in_array( $feature_id, $this->feature_ids, true ) ) {
-			$this->feature_ids[] = $feature_id;
+		if ( ! $this->cache_has( $feature ) ) {
+			$this->cache_put( $feature );
 		}
 
 		/**
@@ -137,8 +130,13 @@ class WP_Feature_Registry {
 	 * @return bool True if the feature was unregistered, false otherwise.
 	 */
 	public function unregister( $feature ) {
-		$feature_id = $feature instanceof WP_Feature ? $feature->get_id() : $feature;
+		$feature = WP_Feature::make( $feature );
 
+		if ( ! $feature ) {
+			return false;
+		}
+
+		$feature_id = $feature->get_id();
 		$feature_obj = $this->repository->find( $feature_id );
 
 		if ( ! $feature_obj ) {
@@ -167,11 +165,12 @@ class WP_Feature_Registry {
 	 * Finds a feature by its ID.
 	 *
 	 * @since 0.1.0
-	 * @param string $feature_id The feature ID to find.
+	 * @param string      $feature_id The feature ID to find.
+	 * @param string|null $type The type of feature to find.
 	 * @return WP_Feature|null The feature if found, null otherwise.
 	 */
-	public function find( $feature_id ) {
-		return $this->repository->find( $feature_id );
+	public function find( $feature_id, $type = null ) {
+		return $this->repository->find( $feature_id, $type );
 	}
 
 	/**
@@ -198,41 +197,6 @@ class WP_Feature_Registry {
 	}
 
 	/**
-	 * Clears the feature ID cache.
-	 *
-	 * @since 0.1.0
-	 * @return void
-	 */
-	public function clear_cache() {
-		$this->feature_ids = array();
-	}
-
-	/**
-	 * Gets all registered feature IDs.
-	 *
-	 * @since 0.1.0
-	 * @return array List of registered feature IDs.
-	 */
-	public function get_registered_ids() {
-		return $this->feature_ids;
-	}
-
-	/**
-	 * Removes a feature ID from the cache.
-	 *
-	 * @since 0.1.0
-	 * @param string $feature_id The feature ID to remove.
-	 * @return void
-	 */
-	private function remove_from_cache( $feature_id ) {
-		$index = array_search( $feature_id, $this->feature_ids, true );
-		if ( false !== $index ) {
-			unset( $this->feature_ids[ $index ] );
-			$this->feature_ids = array_values( $this->feature_ids );
-		}
-	}
-
-	/**
 	 * Removes a feature from the repository and cache.
 	 *
 	 * @since 0.1.0
@@ -246,8 +210,53 @@ class WP_Feature_Registry {
 			return false;
 		}
 
-		$this->remove_from_cache( $feature_id );
+		$this->cache_delete( $feature_id );
 
 		return true;
+	}
+
+	/**
+	 * Clears the feature ID cache.
+	 *
+	 * @since 0.1.0
+	 * @return void
+	 */
+	private function cache_clear() {
+		$this->features = array(
+			WP_Feature::TYPE_RESOURCE => array(),
+			WP_Feature::TYPE_TOOL => array(),
+		);
+	}
+
+	/**
+	 * Removes a feature ID from the cache.
+	 *
+	 * @since 0.1.0
+	 * @param WP_Feature $feature The feature to remove.
+	 * @return void
+	 */
+	private function cache_delete( $feature ) {
+		unset( $this->features[ $feature->get_type() ][ $feature->get_id() ] );
+	}
+
+	/**
+	 * Checks if a feature is cached.
+	 *
+	 * @since 0.1.0
+	 * @param WP_Feature $feature The feature to check.
+	 * @return bool True if the feature is cached, false otherwise.
+	 */
+	private function cache_has( $feature ) {
+		return isset( $this->features[ $feature->get_type() ][ $feature->get_id() ] );
+	}
+
+	/**
+	 * Caches a feature.
+	 *
+	 * @since 0.1.0
+	 * @param WP_Feature $feature The feature to cache.
+	 */
+	private function cache_put( $feature ) {
+		$this->features[ $feature->get_type() ][] = $feature->get_id();
 	}
 }

--- a/includes/class-wp-feature-repository-memory.php
+++ b/includes/class-wp-feature-repository-memory.php
@@ -20,7 +20,10 @@ class WP_Feature_Repository_Memory implements WP_Feature_Repository_Interface {
 	 * @since 0.1.0
 	 * @var array
 	 */
-	private $features = array();
+	private $features = array(
+		WP_Feature::TYPE_RESOURCE => array(),
+		WP_Feature::TYPE_TOOL => array(),
+	);
 
 	/**
 	 * Saves a feature to the repository.
@@ -30,17 +33,13 @@ class WP_Feature_Repository_Memory implements WP_Feature_Repository_Interface {
 	 * @return bool True if the feature was saved successfully, false otherwise.
 	 */
 	public function save( $feature ) {
-		if ( ! $feature instanceof WP_Feature ) {
+		$feature = WP_Feature::make( $feature );
+
+		if ( ! $feature ) {
 			return false;
 		}
 
-		$feature_id = $feature->get_id();
-
-		if ( empty( $feature_id ) ) {
-			return false;
-		}
-
-		$this->features[ $feature_id ] = $feature;
+		$this->features[ $feature->get_type() ][ $feature->get_id() ] = $feature;
 
 		return true;
 	}
@@ -53,14 +52,19 @@ class WP_Feature_Repository_Memory implements WP_Feature_Repository_Interface {
 	 * @return bool True if the feature was deleted successfully, false otherwise.
 	 */
 	public function delete( $feature ) {
-		$feature_id = $feature instanceof WP_Feature ? $feature->get_id() : $feature;
+		$feature = WP_Feature::make( $feature );
 
-		if ( ! isset( $this->features[ $feature_id ] ) ) {
+		if ( ! $feature ) {
 			return false;
 		}
 
-		unset( $this->features[ $feature_id ] );
+		$type_index = $this->features[ $feature->get_type() ];
 
+		if ( ! isset( $type_index[ $feature->get_id() ] ) ) {
+			return false;
+		}
+
+		unset( $type_index[ $feature->get_id() ] );
 		return true;
 	}
 
@@ -68,11 +72,22 @@ class WP_Feature_Repository_Memory implements WP_Feature_Repository_Interface {
 	 * Finds a feature by its ID.
 	 *
 	 * @since 0.1.0
-	 * @param string $feature_id The feature ID to find.
+	 * @param string|WP_Feature $feature The feature ID or feature object to find.
+	 * @param string|null       $type    The type of feature to find.
 	 * @return WP_Feature|null The feature if found, null otherwise.
 	 */
-	public function find( $feature_id ) {
-		return isset( $this->features[ $feature_id ] ) ? $this->features[ $feature_id ] : null;
+	public function find( $feature, $type = null ) {
+		$feature = WP_Feature::make( $feature );
+
+		if ( ! $feature ) {
+			return null;
+		}
+
+		if ( $type ) {
+			return isset( $this->features[ $type ][ $feature->get_id() ] ) ? $this->features[ $type ][ $feature->get_id() ] : null;
+		}
+
+		return isset( $this->features[ $feature->get_type() ][ $feature->get_id() ] ) ? $this->features[ $feature->get_type() ][ $feature->get_id() ] : null;
 	}
 
 	/**
@@ -88,10 +103,11 @@ class WP_Feature_Repository_Memory implements WP_Feature_Repository_Interface {
 		}
 
 		$matches = array();
-
-		foreach ( $this->features as $feature ) {
-			if ( $query->matches( $feature ) ) {
-				$matches[] = $feature;
+		foreach ( $this->features as $type => $features ) {
+			foreach ( $features as $feature ) {
+				if ( $query->matches( $feature ) ) {
+					$matches[] = $feature;
+				}
 			}
 		}
 
@@ -105,7 +121,10 @@ class WP_Feature_Repository_Memory implements WP_Feature_Repository_Interface {
 	 * @return array All features.
 	 */
 	public function get_all() {
-		return array_values( $this->features );
+		return array_merge(
+			array_values( $this->features[ WP_Feature::TYPE_RESOURCE ] ),
+			array_values( $this->features[ WP_Feature::TYPE_TOOL ] )
+		);
 	}
 
 	/**

--- a/includes/class-wp-feature.php
+++ b/includes/class-wp-feature.php
@@ -41,6 +41,14 @@ class WP_Feature implements \JsonSerializable {
 	);
 
 	/**
+	 * Default feature type constant.
+	 *
+	 * @since 0.1.0
+	 * @var string
+	 */
+	const TYPE_DEFAULT = self::TYPE_RESOURCE;
+
+	/**
 	 * Server location constant.
 	 *
 	 * @since 0.1.0
@@ -84,6 +92,14 @@ class WP_Feature implements \JsonSerializable {
 	 * @var string
 	 */
 	private $name;
+
+	/**
+	 * Whether the feature has a REST alias.
+	 *
+	 * @since 0.1.0
+	 * @var bool
+	 */
+	private $rest_alias = false;
 
 	/**
 	 * The feature description.
@@ -209,66 +225,46 @@ class WP_Feature implements \JsonSerializable {
 	}
 
 	/**
-	 * Sets the properties of the feature.
+	 * Makes a feature from various input types.
 	 *
 	 * @since 0.1.0
-	 * @param array $args The feature arguments.
-	 * @return WP_Error|true WP_Error if validation fails, true otherwise.
+	 * @param WP_Feature|array|string $feature The feature to make.
+	 * @return WP_Feature|false The feature if successful, false otherwise.
 	 */
-	private function set_props( $args ) {
-		$args = wp_parse_args(
-			$args,
-			array(
-				'type'         => 'resource',
-				'name'         => '',
-				'description'  => '',
-				'meta'         => array(),
-				'categories'   => array(),
-				'input_schema' => array(),
-				'output_schema' => array(),
-				'callback'     => null,
-				'permissions'  => '',
-				'filter'       => null,
-			)
-		);
+	public static function make( $feature ) {
+		if ( is_array( $feature ) ) {
+			if ( ! isset( $feature['id'] ) ) {
+				return false;
+			}
 
-		if ( empty( $args['name'] ) ) {
-			return new WP_Error( 'missing_name', __( 'Feature name is required.', 'wp-feature-api' ) );
+			$feature = new WP_Feature( $feature['id'], $feature );
 		}
 
-		if ( empty( $args['description'] ) ) {
-			return new WP_Error( 'missing_description', __( 'Feature description is required.', 'wp-feature-api' ) );
+		if ( is_string( $feature ) ) {
+			$feature = new WP_Feature( $feature );
 		}
 
-		if ( ! in_array( $args['type'], self::TYPES, true ) ) {
-			return new WP_Error( 'invalid_type', __( 'Feature type must be either "resource" or "tool".', 'wp-feature-api' ) );
+		if ( $feature instanceof WP_Feature ) {
+			$feature->register_rest_alias();
+			return $feature;
 		}
 
-		// Sanitize text fields.
-		$this->name        = sanitize_text_field( $args['name'] );
-		$this->description = sanitize_text_field( $args['description'] );
-		$this->type        = $args['type'];
+		return false;
+	}
 
-		// Meta should be an array.
-		$this->meta = is_array( $args['meta'] ) ? $args['meta'] : array();
+	/**
+	 * Gets the feature type from a request method.
+	 *
+	 * @since 0.1.0
+	 * @param string $method The request method.
+	 * @return string The feature type.
+	 */
+	public static function type_from_request_method( $method ) {
+		if ( 'POST' === strtoupper( $method ) ) {
+			return self::TYPE_TOOL;
+		}
 
-		// Categories should be an array.
-		$this->categories = is_array( $args['categories'] ) ? $args['categories'] : array();
-
-		// Schema values should be arrays.
-		$this->input_schema  = is_array( $args['input_schema'] ) ? $args['input_schema'] : array();
-		$this->output_schema = is_array( $args['output_schema'] ) ? $args['output_schema'] : array();
-
-		// Callback must be callable or null.
-		$this->callback = is_callable( $args['callback'] ) || null === $args['callback'] ? $args['callback'] : null;
-
-		// Permissions can be string, array, or callable.
-		$this->permissions = $args['permissions'];
-
-		// Filter must be callable or null.
-		$this->filter = is_callable( $args['filter'] ) || null === $args['filter'] ? $args['filter'] : null;
-
-		return true;
+		return self::TYPE_RESOURCE;
 	}
 
 	/**
@@ -402,6 +398,30 @@ class WP_Feature implements \JsonSerializable {
 	}
 
 	/**
+	 * Whether the feature has a REST alias.
+	 *
+	 * @since 0.1.0
+	 * @return bool Whether the feature has a REST alias.
+	 */
+	public function has_rest_alias() {
+		return $this->rest_alias;
+	}
+
+	/**
+	 * Gets the REST method for the feature based on the feature type.
+	 *
+	 * @since 0.1.0
+	 * @return string The REST method.
+	 */
+	public function get_rest_method() {
+		if ( self::TYPE_TOOL === $this->type ) {
+			return WP_REST_Server::CREATABLE;
+		}
+
+		return WP_REST_Server::READABLE;
+	}
+
+	/**
 	 * Runs the feature.
 	 *
 	 * @since 0.1.0
@@ -452,7 +472,9 @@ class WP_Feature implements \JsonSerializable {
 		do_action( 'wp_feature_before_run', $context, $this );
 		do_action( $this->get_filter_id() . '_before_run', $context, $this );
 		// Run the feature callback.
-		$result = call_user_func( $this->callback, $context );
+
+		$rest_request = new WP_REST_Request( $this->get_rest_method(), $context );
+		$result = call_user_func( $this->callback, $rest_request );
 
 		/**
 		 * Filters the result after running a feature.
@@ -496,6 +518,81 @@ class WP_Feature implements \JsonSerializable {
 
 		return $result;
 	}
+
+	/**
+	 * Sets the properties of the feature.
+	 *
+	 * @since 0.1.0
+	 * @param array $args The feature arguments.
+	 * @return WP_Error|true WP_Error if validation fails, true otherwise.
+	 */
+	private function set_props( $args ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'type'         => self::TYPE_DEFAULT,
+				'name'         => '',
+				'description'  => '',
+				'meta'         => array(),
+				'categories'   => array(),
+				'input_schema' => array(),
+				'output_schema' => array(),
+				'callback'     => null,
+				'permissions'  => '',
+				'filter'       => null,
+				'rest_alias'   => false,
+			)
+		);
+
+		if ( empty( $args['name'] ) ) {
+			return new WP_Error( 'missing_name', __( 'Feature name is required.', 'wp-feature-api' ) );
+		}
+
+		if ( empty( $args['description'] ) ) {
+			return new WP_Error( 'missing_description', __( 'Feature description is required.', 'wp-feature-api' ) );
+		}
+
+		if ( ! in_array( $args['type'], self::TYPES, true ) ) {
+			return new WP_Error(
+				'invalid_type',
+				sprintf(
+					/* translators: %s: Feature type */
+					__( 'Feature type must be one of: %s', 'wp-feature-api' ),
+					implode( ', ', self::TYPES )
+				)
+			);
+		}
+
+		// Sanitize text fields.
+		$this->name        = sanitize_text_field( $args['name'] );
+		$this->description = sanitize_text_field( $args['description'] );
+		$this->type        = $args['type'];
+
+		// Meta should be an array.
+		$this->meta = is_array( $args['meta'] ) ? $args['meta'] : array();
+
+		// Categories should be an array.
+		$this->categories = is_array( $args['categories'] ) ? $args['categories'] : array();
+
+		// Schema values should be arrays.
+		$this->input_schema  = is_array( $args['input_schema'] ) ? $args['input_schema'] : array();
+		$this->output_schema = is_array( $args['output_schema'] ) ? $args['output_schema'] : array();
+
+		// Callback must be callable or null.
+		$this->callback = is_callable( $args['callback'] ) || null === $args['callback'] ? $args['callback'] : null;
+
+		// Permissions can be string, array, or callable.
+		$this->permissions = $args['permissions'];
+
+		// Filter must be callable or null.
+		$this->filter = is_callable( $args['filter'] ) || null === $args['filter'] ? $args['filter'] : null;
+
+		// Rest alias must be false or a string.
+		$this->rest_alias = false === $args['rest_alias'] || is_string( $args['rest_alias'] ) ? $args['rest_alias'] : false;
+
+		return true;
+	}
+
 
 	/**
 	 * Validates the input against the schema.
@@ -592,6 +689,111 @@ class WP_Feature implements \JsonSerializable {
 	}
 
 	/**
+	 * Checks if the feature is a REST alias.
+	 *
+	 * @since 0.1.0
+	 * @return bool Whether the feature is a REST alias.
+	 */
+	public function is_rest_alias() {
+		return false !== $this->rest_alias;
+	}
+
+	/**
+	 * Gets the alternate types for the feature.
+	 *
+	 * @since 0.1.0
+	 * @return array The alternate types.
+	 */
+	public function get_alternate_types() {
+		$alternate_types = array_diff( self::TYPES, array( $this->type ) );
+		$alternate_features = array();
+		foreach ( $alternate_types as $type ) {
+			$feature = wp_feature_registry()->find( $this->id, $type );
+			if ( $feature instanceof WP_Feature ) {
+				$alternate_features[] = $feature;
+			}
+		}
+
+		return $alternate_features;
+	}
+
+	/**
+	 * Sets the feature from a REST alias.
+	 *
+	 * @since 0.1.0
+	 * @return WP_Feature The feature object or WP_Error if the REST alias is not found.
+	 */
+	public function set_from_rest_alias() {
+		$rest_alias = $this->get_rest_alias();
+
+		if ( is_wp_error( $rest_alias ) ) {
+			return $rest_alias;
+		}
+
+		if ( isset( $rest_alias['args'] ) ) {
+			$this->input_schema = $rest_alias['args'];
+		}
+
+		if ( isset( $rest_alias['schema'] ) ) {
+			$this->output_schema = $rest_alias['schema'];
+		}
+
+		if ( isset( $rest_alias['permission_callback'] ) ) {
+			$this->permissions = $rest_alias['permission_callback'];
+		}
+
+		if ( isset( $rest_alias['callback'] ) && is_callable( $rest_alias['callback'] ) ) {
+			$this->callback = $rest_alias['callback'];
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Checks if a feature has a REST alias.
+	 *
+	 * @since 0.1.0
+	 * @return array|WP_Error The REST alias if found, WP_Error otherwise.
+	 */
+	private function get_rest_alias() {
+		$routes = rest_get_server()->get_routes();
+		$feature_route = $this->rest_alias;
+
+		if ( ! isset( $routes[ $feature_route ] ) ) {
+			return new WP_Error(
+				'rest_alias_not_found',
+				sprintf(
+					/* translators: %1$s: Feature name, %2$s: REST route path */
+					__( 'REST API alias of feature (%1$s) not found. Check if the REST route %2$s exists.', 'wp-feature-api' ),
+					$this->id,
+					$feature_route
+				),
+				array( 'status' => 404 )
+			);
+		}
+
+		$method = $this->get_rest_method();
+
+		foreach ( $routes[ $feature_route ] as $route_handler ) {
+			$methods = array_keys( $route_handler['methods'] );
+			if ( in_array( $method, $methods, true ) ) {
+				return $route_handler;
+			}
+		}
+
+		return new WP_Error(
+			'rest_alias_method_not_supported',
+			sprintf(
+				/* translators: %1$s: Feature name, %2$s: HTTP method */
+				__( 'REST API alias of feature (%1$s) does not support the method %2$s.', 'wp-feature-api' ),
+				$feature->get_id(),
+				$method
+			),
+			array( 'status' => 405 )
+		);
+	}
+
+	/**
 	 * Gets the filter ID for use in actions and filters following the WordPress filter naming convention.
 	 *
 	 * @since 0.1.0
@@ -648,5 +850,17 @@ class WP_Feature implements \JsonSerializable {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Registers data from the REST alias if it exists.
+	 *
+	 * @since 0.1.0
+	 * @return void
+	 */
+	private function register_rest_alias() {
+		if ( $this->is_rest_alias() ) {
+			$this->set_from_rest_alias();
+		}
 	}
 }

--- a/includes/default-wp-features.php
+++ b/includes/default-wp-features.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Core WordPress Features
+ *
+ * @package WordPress\Features_API
+ */
+
+/**
+ * Register core WordPress features.
+ *
+ * @since 0.1.0
+ * @return void
+ */
+function wp_feature_api_register_core_features() {
+	$core_features = array(
+		/**
+		 * Posts
+		 */
+		array(
+			'id'          => 'posts',
+			'name'        => __( 'Query posts', 'wp-feature-api' ),
+			'description' => __( 'Get a list of posts that match the query parameters.', 'wp-feature-api' ),
+			'rest_alias'  => '/wp/v2/posts',
+			'categories'  => array( 'core', 'post', 'rest' ),
+			'type'        => 'resource',
+		),
+		array(
+			'id'          => 'posts',
+			'name'        => __( 'Create post', 'wp-feature-api' ),
+			'description' => __( 'Create a new post.', 'wp-feature-api' ),
+			'rest_alias'  => '/wp/v2/posts',
+			'categories'  => array( 'core', 'post', 'rest' ),
+			'type'        => 'tool',
+		),
+		array(
+			'id'          => 'post',
+			'name'        => __( 'View a post', 'wp-feature-api' ),
+			'description' => __( 'Get a post by its ID.', 'wp-feature-api' ),
+			'rest_alias'  => '/wp/v2/posts/(?P<id>[\d]+)',
+			'categories'  => array( 'core', 'post', 'rest' ),
+			'type'        => 'resource',
+		),
+		/**
+		 * Users
+		 */
+		array(
+			'id'          => 'users',
+			'name'        => __( 'Query users', 'wp-feature-api' ),
+			'description' => __( 'Get a list of users that match the query parameters.', 'wp-feature-api' ),
+			'rest_alias'  => '/wp/v2/users',
+			'categories'  => array( 'core', 'user', 'rest' ),
+			'type'        => 'resource',
+		),
+		array(
+			'id'          => 'users',
+			'name'        => __( 'Create user', 'wp-feature-api' ),
+			'description' => __( 'Create a new user.', 'wp-feature-api' ),
+			'rest_alias'  => '/wp/v2/users',
+			'categories'  => array( 'core', 'user', 'rest' ),
+			'type'        => 'tool',
+		),
+		array(
+			'id'          => 'user',
+			'name'        => __( 'View a user', 'wp-feature-api' ),
+			'description' => __( 'Get a user by their ID.', 'wp-feature-api' ),
+			'rest_alias'  => '/wp/v2/users/(?P<id>[\d]+)',
+			'categories'  => array( 'core', 'user', 'rest' ),
+			'type'        => 'resource',
+		),
+		array(
+			'id'          => 'users/me',
+			'name'        => __( 'Get current user', 'wp-feature-api' ),
+			'description' => __( 'Get the current user.', 'wp-feature-api' ),
+			'rest_alias'  => '/wp/v2/users/me',
+			'categories'  => array( 'core', 'user', 'rest' ),
+			'type'        => 'resource',
+		),
+	);
+	$core_features = apply_filters( 'wp_feature_api_core_features', $core_features );
+
+	foreach ( $core_features as $feature ) {
+		wp_register_feature( $feature );
+	}
+}
+
+// Register core features on init.
+add_action( 'init', 'wp_feature_api_register_core_features' );

--- a/includes/interface-wp-feature-repository.php
+++ b/includes/interface-wp-feature-repository.php
@@ -36,10 +36,11 @@ interface WP_Feature_Repository_Interface {
 	 * Finds a feature by its ID.
 	 *
 	 * @since 0.1.0
-	 * @param string $feature_id The feature ID to find.
+	 * @param string|WP_Feature $feature The feature ID or feature object to find.
+	 * @param string|null       $type    The type of feature to find.
 	 * @return WP_Feature|null The feature if found, null otherwise.
 	 */
-	public function find( $feature_id );
+	public function find( $feature, $type = null );
 
 	/**
 	 * Queries features based on a query.

--- a/includes/rest-api/class-wp-rest-feature-controller.php
+++ b/includes/rest-api/class-wp-rest-feature-controller.php
@@ -21,6 +21,14 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 	private $default_fields = array( 'id', 'name', 'description', 'type', 'categories', 'metadata' );
 
 	/**
+	 * Path for the run endpoint.
+	 *
+	 * @since 0.1.0
+	 * @var string
+	 */
+	private $run_path = 'run';
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 0.1.0
@@ -59,25 +67,10 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 	public function register_routes() {
 		$resource_base = '/' . $this->rest_base . '/(?P<id>' . WP_Feature::ID_PATTERN . ')';
 
-		// Register GET endpoint for retrieving all features with pagination.
+		// Register endpoint for executing features.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base,
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_items' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-					'args'                => $this->get_collection_params(),
-				),
-				'schema' => array( $this, 'get_items_schema' ),
-			)
-		);
-
-		// Register GET endpoint for retrieving a specific feature by ID.
-		register_rest_route(
-			$this->namespace,
-			$resource_base,
+			$resource_base . '/' . $this->run_path,
 			array(
 				'args'   => array(
 					'id' => array(
@@ -86,31 +79,16 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 						'required'    => true,
 						'pattern'     => WP_Feature::ID_PATTERN,
 					),
-				),
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_item' ),
-					'permission_callback' => array( $this, 'get_item_permissions_check' ),
-				),
-				'schema' => array( $this, 'get_item_schema' ),
-			)
-		);
-
-		// Register POST endpoint for executing tool features.
-		register_rest_route(
-			$this->namespace,
-			$resource_base . '/run',
-			array(
-				'args'   => array(
-					'id' => array(
-						'description' => __( 'Unique identifier for the feature.', 'wp-feature-api' ),
+					'type' => array(
+						'description' => __( 'Type of the feature.', 'wp-feature-api' ),
 						'type'        => 'string',
+						'enum'        => WP_Feature::TYPES,
+						'default'     => WP_Feature::TYPE_DEFAULT,
 						'required'    => true,
-						'pattern'     => WP_Feature::ID_PATTERN,
 					),
 				),
 				array(
-					'methods'             => WP_REST_Server::CREATABLE,
+					'methods'             => array( WP_REST_Server::CREATABLE, WP_REST_Server::READABLE ),
 					'callback'            => array( $this, 'run_item' ),
 					'permission_callback' => array( $this, 'run_item_permissions_check' ),
 					'args'                => array(
@@ -145,6 +123,50 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 					'callback'            => array( $this, 'query_items' ),
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 					'args'                => $this->get_query_params(),
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			)
+		);
+
+		// Register GET endpoint for retrieving all features with pagination.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_items_schema' ),
+			)
+		);
+
+		// Register GET endpoint for retrieving a specific feature by ID.
+		register_rest_route(
+			$this->namespace,
+			$resource_base,
+			array(
+				'args'   => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the feature.', 'wp-feature-api' ),
+						'type'        => 'string',
+						'required'    => true,
+						'pattern'     => WP_Feature::ID_PATTERN,
+					),
+					'type' => array(
+						'description' => __( 'Type of the feature.', 'wp-feature-api' ),
+						'type'        => 'string',
+						'enum'        => WP_Feature::TYPES,
+						'default'     => WP_Feature::TYPE_DEFAULT,
+						'required'    => true,
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				),
 				'schema' => array( $this, 'get_item_schema' ),
 			)
@@ -198,24 +220,20 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 	 */
 	public function get_item( $request ) {
 		$id = $request['id'];
+		$type = $request['type'];
 
 		$registry = WP_Feature_Registry::get_instance();
-		$feature  = $registry->find( $id );
+		$feature  = $registry->find( $id, $type );
+
+		if ( is_wp_error( $feature ) ) {
+			return $feature;
+		}
 
 		if ( ! $feature ) {
 			return new WP_Error(
 				'rest_feature_not_found',
 				__( 'Feature not found.', 'wp-feature-api' ),
 				array( 'status' => 404 )
-			);
-		}
-
-		// If type is 'tool', return error that POST is required for tool features.
-		if ( WP_Feature::TYPE_TOOL === $feature->get_type() ) {
-			return new WP_Error(
-				'rest_feature_invalid_method',
-				__( 'Tool features must be accessed via POST to the /run endpoint.', 'wp-feature-api' ),
-				array( 'status' => 405 )
 			);
 		}
 
@@ -226,7 +244,7 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Runs a tool feature.
+	 * Runs a feature.
 	 *
 	 * @since 0.1.0
 	 *
@@ -234,33 +252,16 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function run_item( $request ) {
-		$id      = $request['id'];
 		$context = $request->get_param( 'context' );
+		$type = WP_Feature::type_from_request_method( $request->get_method() );
+		$feature = wp_feature_registry()->find( $request['id'], $type );
 
-		$registry = WP_Feature_Registry::get_instance();
-		$feature  = $registry->find( $id );
-
-		if ( ! $feature ) {
-			return new WP_Error(
-				'rest_feature_not_found',
-				__( 'Feature not found.', 'wp-feature-api' ),
-				array( 'status' => 404 )
-			);
+		if ( is_wp_error( $feature ) ) {
+			return $feature;
 		}
 
-		// Return error if feature is not a tool.
-		if ( WP_Feature::TYPE_TOOL !== $feature->get_type() ) {
-			return new WP_Error(
-				'rest_feature_invalid_type',
-				__( 'Only tool features can be rund.', 'wp-feature-api' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		// Execute the feature.
 		$result = $feature->run( $context );
 
-		// Check if the result is an error.
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
@@ -410,7 +411,7 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
 	public function run_item_permissions_check( $request ) {
-		$feature  = wp_feature_registry()->find( $request['id'] );
+		$feature = wp_feature_registry()->find( $request['id'] );
 
 		if ( ! $feature ) {
 			return true; // Let the callback handle the 404.
@@ -469,23 +470,11 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 	public function prepare_item_for_response( $feature, $request ) {
 		$data = $this->transform_feature_data( $feature, $request );
 
-		// Add _links for REST API discoverability.
-		$links = array(
-			'self' => array(
-				'href' => rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $feature->get_id() ) ),
-			),
-		);
-
-		// Add run link for tool features.
-		if ( WP_Feature::TYPE_TOOL === $feature->get_type() ) {
-			$links['run'] = array(
-				'href'   => rest_url( sprintf( '%s/%s/%s/run', $this->namespace, $this->rest_base, $feature->get_id() ) ),
-				'method' => WP_REST_Server::CREATABLE,
-			);
-		}
-
 		$response = rest_ensure_response( $data );
-		$response->add_links( $links );
+		$links = $this->get_links( $feature );
+		if ( ! empty( $links ) ) {
+			$response->add_links( $links );
+		}
 
 		return $response;
 	}
@@ -667,5 +656,87 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 		}
 
 		return array_intersect_key( $data, array_flip( $fields ) );
+	}
+
+	/**
+	 * Retrieves the links for a feature.
+	 * Helps with discoverability of the feature and its alternate types.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_Feature $feature The feature object.
+	 * @return array The links for the feature.
+	 */
+	private function get_links( $feature ) {
+		$links = array(
+			'self' => array(
+				'href' => $this->get_feature_url( $feature ),
+			),
+			'run' => array(
+				array(
+					'href'   => $this->get_feature_run_url( $feature ),
+					'method' => $feature->get_rest_method(),
+				),
+			),
+		);
+
+		// Add related links for other feature types with the same ID.
+		$alternate_features = $feature->get_alternate_types();
+		if ( $alternate_features ) {
+			foreach ( $alternate_features as $alternate_feature ) {
+				$url = $this->get_feature_url( $alternate_feature );
+				$links['related'][] = array(
+					'href'   => add_query_arg( 'type', $alternate_feature->get_type(), $url ),
+					'method' => 'GET',
+				);
+
+				$links['related'][] = array(
+					'href'   => $this->get_feature_run_url( $alternate_feature ),
+					'method' => $alternate_feature->get_rest_method(),
+				);
+			}
+		}
+
+		return $links;
+	}
+
+	/**
+	 * Retrieves the base resource path for a feature.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_Feature $feature The feature object.
+	 * @return string The base path for the feature.
+	 */
+	private function get_base_path( $feature ) {
+		if ( $feature ) {
+			return sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $feature->get_id() );
+		}
+
+		return sprintf( '%s/%s', $this->namespace, $this->rest_base );
+	}
+
+	/**
+	 * Retrieves the URL for a feature.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_Feature $feature The feature object.
+	 * @return string The URL for the feature.
+	 */
+	private function get_feature_url( $feature ) {
+		return rest_url( $this->get_base_path( $feature ) );
+	}
+
+	/**
+	 * Retrieves the URL for the run endpoint of a feature.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_Feature $feature The feature object.
+	 * @return string The URL for the run endpoint of the feature.
+	 */
+	private function get_feature_run_url( $feature ) {
+		return $this->get_feature_url( $feature ) . '/' . $this->run_path;
 	}
 }

--- a/includes/rest-api/class-wp-rest-feature-controller.php
+++ b/includes/rest-api/class-wp-rest-feature-controller.php
@@ -18,7 +18,7 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 	 * @since 0.1.0
 	 * @var array
 	 */
-	private $default_fields = array( 'id', 'name', 'description', 'type', 'categories', 'metadata' );
+	private $default_fields = array( 'id', 'name', 'description', 'type', 'categories', 'metadata', 'input_schema', 'output_schema' );
 
 	/**
 	 * Path for the run endpoint.

--- a/includes/rest-api/class-wp-rest-feature-controller.php
+++ b/includes/rest-api/class-wp-rest-feature-controller.php
@@ -113,21 +113,6 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 			)
 		);
 
-		// Register GET endpoint for querying features.
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/query',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'query_items' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-					'args'                => $this->get_query_params(),
-				),
-				'schema' => array( $this, 'get_item_schema' ),
-			)
-		);
-
 		// Register GET endpoint for retrieving all features with pagination.
 		register_rest_route(
 			$this->namespace,
@@ -182,6 +167,9 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
+		// @todo: Create query object.
+		// $query = new WP_Feature_Query( $query_args );
+
 		$features = wp_feature_registry()->get();
 
 		// Handle pagination.
@@ -267,67 +255,6 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 		}
 
 		$response = rest_ensure_response( $result );
-		return $response;
-	}
-
-	/**
-	 * Queries features based on criteria.
-	 *
-	 * @since 0.1.0
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 */
-	public function query_items( $request ) {
-		$registry = WP_Feature_Registry::get_instance();
-
-		// Build query args from request parameters.
-		$query_args = array();
-
-		// Filter by type.
-		if ( ! empty( $request['type'] ) ) {
-			$query_args['type'] = $request['type'];
-		}
-
-		// Filter by category.
-		if ( ! empty( $request['category'] ) ) {
-			$query_args['categories'] = array( $request['category'] );
-		}
-
-		// Filter by location.
-		if ( ! empty( $request['location'] ) ) {
-			$query_args['location'] = $request['location'];
-		}
-
-		// Create query object.
-		$query = new WP_Feature_Query( $query_args );
-
-		// Get features based on query.
-		$features = $registry->get( $query );
-
-		// Handle pagination.
-		$page     = $request['page'] ?? 1;
-		$per_page = $request['per_page'] ?? 10;
-		$offset   = ( $page - 1 ) * $per_page;
-
-		$total_features = count( $features );
-		$max_pages      = ceil( $total_features / $per_page );
-
-		// Apply pagination.
-		$features = array_slice( $features, $offset, $per_page );
-
-		$data = array();
-		foreach ( $features as $feature ) {
-			$item   = $this->prepare_item_for_response( $feature, $request );
-			$data[] = $this->prepare_response_for_collection( $item );
-		}
-
-		$response = rest_ensure_response( $data );
-
-		// Add pagination headers.
-		$response->header( 'X-WP-Total', $total_features );
-		$response->header( 'X-WP-TotalPages', $max_pages );
-
 		return $response;
 	}
 

--- a/wp-feature-api.php
+++ b/wp-feature-api.php
@@ -50,6 +50,9 @@ function wp_feature_api_init() {
 	// Include global functions.
 	require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/wp-feature.php';
 
+	// Include core features.
+	require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/default-wp-features.php';
+
 	// Initialize the REST API endpoints.
 	require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/rest-api/class-wp-rest-feature-controller.php';
 


### PR DESCRIPTION
This adds a `rest_alias` property to a `WP_Feature` so that that we can reuse the properties of already registered REST endpoints. I added a handful of these under `includes/default-wp-features.php`. Here we essentially are defining the basic feature properties like name, description, category and if the rest alias route exists we reuse properties like callback, input/output schema (args, schema), permissions, etc for the feature. 

The REST endpoints for WP Features now look like this:

```
GET:      /wp/v2/features                 # Get/query features
GET:      /wp/v2/features/[id]          # Get feature by id
POST:   /wp/v2/features/[id]/run    # Runs a tool feature using its context
GET:      /wp/v2/features/[id]/run    # Runs a resource feature using its context
```
<img width="742" alt="Screenshot 2025-03-25 at 08 09 34" src="https://github.com/user-attachments/assets/376a51a4-ac38-44ef-b77c-ec9052a6ebab" />

A links property is provided on the feature resource to indicate its run endpoints for either tools or resources, as well as if it has a corresponding `tool` or `resource` with the same ID. 

On that note, I've structured feature IDs to be unique within their respective types (tool or resource), but not necessarily across types. This means while the same ID may be used for both a tool and a resource feature, the combination of type and id creates a unique identifier for any feature in the system. I did this because it's analogous to the REST API where the route "ID" `posts` can be GET or POST. I'm not sure if this is a good move, what do you think @jorgefilipecosta ?