### PR TITLE
Rename features-api into feature-api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ build-style
 build-types
 build-wp
 node_modules
-wp-features-api.zip
+wp-feature-api.zip
 coverage
 .phpunit.result.cache
 .reassure

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "wp-features-api",
+	"name": "wp-feature-api",
 	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "wp-features-api",
+			"name": "wp-feature-api",
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "wp-features-api",
+	"name": "wp-feature-api",
 	"version": "1.0.0",
 	"description": "A system for exposing WordPress functionality in a standardized, discoverable way for both server and client-side use",
 	"main": "src/index.js",

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "wp-features-api",
+	"name": "wp-feature-api",
 	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "wp-features-api",
+			"name": "wp-feature-api",
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {

--- a/wp-feature-api.php
+++ b/wp-feature-api.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WordPress Feature API
- * Plugin URI: https://wordpress.org/plugins/wp-features-api/
+ * Plugin URI: https://wordpress.org/plugins/wp-feature-api/
  * Description: A system for exposing server and client-side functionality in WordPress for use in LLMs and agentic systems.
  * Version: 0.1.0
  * Author: WordPress Contributors


### PR DESCRIPTION
We were inconsistently using features-api and feature-api. This PR renames all the instances of artifact naming to feature-api.