### PR TITLE
Add more detailed categories

### DIFF
--- a/includes/class-wp-feature-categories.php
+++ b/includes/class-wp-feature-categories.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * WP_Feature_Categories class file.
+ *
+ * @package WordPress\Features_API
+ */
+
+/**
+ * Class WP_Feature_Categories
+ *
+ * Manages a collection of feature categories.
+ *
+ * @since 0.1.0
+ */
+final class WP_Feature_Categories {
+
+	/**
+	 * Array of category objects.
+	 *
+	 * @since 0.1.0
+	 * @var array
+	 */
+	private $categories = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 0.1.0
+	 */
+	public function __construct() {
+		$this->register_default_categories();
+	}
+
+	/**
+	 * Gets all categories.
+	 *
+	 * @since 0.1.0
+	 * @return array Array of WP_Feature_Category objects.
+	 */
+	public function get_all() {
+		return $this->categories;
+	}
+
+	/**
+	 * Gets a category by slug.
+	 *
+	 * @since 0.1.0
+	 * @param string $slug Category slug.
+	 * @return WP_Feature_Category|null Category object or null if not found.
+	 */
+	public function get( $slug ) {
+		return isset( $this->categories[ $slug ] ) ? $this->categories[ $slug ] : null;
+	}
+
+	/**
+	 * Adds or updates a category.
+	 *
+	 * @since 0.1.0
+	 * @param string|array|WP_Feature_Category $category Category data.
+	 * @return WP_Feature_Category|null Category object or null on failure.
+	 */
+	public function add( $category ) {
+		$category_obj = WP_Feature_Category::make( $category );
+
+		if ( ! $category_obj ) {
+			return null;
+		}
+
+		$slug = $category_obj->get_slug();
+
+		if ( isset( $this->categories[ $slug ] ) ) {
+			// Update existing category.
+			$existing = $this->categories[ $slug ];
+			if ( ! empty( $category_obj->get_name() ) ) {
+				$existing->set_name( $category_obj->get_name() );
+			}
+			if ( ! empty( $category_obj->get_description() ) ) {
+				$existing->set_description( $category_obj->get_description() );
+			}
+
+			$category_obj = $existing;
+		}
+
+		$this->categories[ $slug ] = $category_obj;
+		$this->categories[ $slug ]->increment_count();
+
+		return $this->categories[ $slug ];
+	}
+
+	/**
+	 * Removes a category.
+	 *
+	 * @since 0.1.0
+	 * @param string $slug Category slug.
+	 * @return bool True if category was removed, false otherwise.
+	 */
+	public function remove( $slug ) {
+		$category_obj = WP_Feature_Category::make( $slug );
+		$slug = $category_obj->get_slug();
+
+		if ( ! isset( $this->categories[ $slug ] ) ) {
+			return false;
+		}
+
+		$existing = $this->categories[ $slug ];
+		$existing->decrement_count();
+		if ( 0 === $existing->get_feature_count() ) {
+			unset( $this->categories[ $slug ] );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Updates categories for a feature.
+	 *
+	 * @since 0.1.0
+	 * @param WP_Feature $feature Feature object.
+	 * @return void
+	 */
+	public function update_for_feature( $feature ) {
+		if ( ! $feature instanceof WP_Feature ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: WP_Feature */
+					__( 'The feature must be an instance of %s.', 'wp-feature-api' ),
+					'WP_Feature'
+				),
+				'0.1.0'
+			);
+		}
+
+		$feature_categories = $feature->get_categories();
+
+		if ( empty( $feature_categories ) ) {
+			return;
+		}
+
+		/**
+		 * Filters the categories before they are registered.
+		 *
+		 * @since 0.1.0
+		 * @param array      $feature_categories The categories to be registered.
+		 * @param WP_Feature $feature           The feature being registered.
+		 */
+		$feature_categories = apply_filters( 'wp_feature_pre_register_categories', $feature_categories, $feature );
+
+		foreach ( $feature_categories as $category ) {
+			$this->add( $category );
+		}
+	}
+
+	/**
+	 * Removes categories for a feature.
+	 *
+	 * @since 0.1.0
+	 * @param WP_Feature $feature Feature object.
+	 * @return void
+	 */
+	public function remove_for_feature( $feature ) {
+		if ( ! $feature instanceof WP_Feature ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: WP_Feature */
+					__( 'The feature must be an instance of %s.', 'wp-feature-api' ),
+					'WP_Feature'
+				),
+				'0.1.0'
+			);
+		}
+
+		$feature_categories = $feature->get_categories();
+
+		if ( empty( $feature_categories ) ) {
+			return;
+		}
+
+		foreach ( $feature_categories as $category ) {
+			$this->remove( $category );
+		}
+	}
+
+	/**
+	 * Registers default categories.
+	 *
+	 * @since 0.1.0
+	 */
+	private function register_default_categories() {
+		/**
+		 * Filters the default categories to be registered.
+		 *
+		 * Expected format:
+		 * array(
+		 *     'category-slug' => array(
+		 *         'name'        => 'Category Name',
+		 *         'description' => 'Category Description',
+		 *     ),
+		 * )
+		 *
+		 * @since 0.1.0
+		 * @param array $default_categories Array of default categories.
+		 */
+		$default_categories = apply_filters( 'wp_feature_default_categories', array() );
+
+		foreach ( $default_categories as $slug => $category ) {
+			$category_data = array_merge(
+				array( 'slug' => $slug ),
+				$category
+			);
+			$this->add( $category_data );
+		}
+	}
+}

--- a/includes/class-wp-feature-categories.php
+++ b/includes/class-wp-feature-categories.php
@@ -56,46 +56,77 @@ final class WP_Feature_Categories {
 	 * Adds or updates a category.
 	 *
 	 * @since 0.1.0
+	 *
 	 * @param string|array|WP_Feature_Category $category Category data.
-	 * @return WP_Feature_Category|null Category object or null on failure.
+	 * @return WP_Feature_Category|WP_Error Category object on success, WP_Error on failure.
 	 */
 	public function add( $category ) {
-		$category_obj = WP_Feature_Category::make( $category );
+		$cat = WP_Feature_Category::make( $category );
 
-		if ( ! $category_obj ) {
-			return null;
+		if ( ! $cat ) {
+			return new WP_Error(
+				'invalid_category',
+				__( 'Invalid category data provided.', 'wp-feature-api' )
+			);
 		}
 
-		$slug = $category_obj->get_slug();
+		$slug = $cat->get_slug();
 
 		if ( isset( $this->categories[ $slug ] ) ) {
-			// Update existing category.
-			$existing = $this->categories[ $slug ];
-			if ( ! empty( $category_obj->get_name() ) ) {
-				$existing->set_name( $category_obj->get_name() );
-			}
-			if ( ! empty( $category_obj->get_description() ) ) {
-				$existing->set_description( $category_obj->get_description() );
-			}
-
-			$category_obj = $existing;
+			$this->update_existing_category( $this->categories[ $slug ], $cat );
+			$cat = $this->categories[ $slug ];
+		} else {
+			$this->categories[ $slug ] = $cat;
 		}
 
-		$this->categories[ $slug ] = $category_obj;
-		$this->categories[ $slug ]->increment_count();
+		/**
+		 * Fires after a category is added or updated.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param WP_Feature_Category $cat     The category object.
+		 * @param bool               $is_update True if this was an update, false if a new category.
+		 */
+		do_action( 'wp_feature_category_added', $cat, isset( $this->categories[ $slug ] ) );
 
-		return $this->categories[ $slug ];
+		return $cat;
+	}
+
+	/**
+	 * Updates an existing category with new data.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_Feature_Category $existing Existing category object.
+	 * @param WP_Feature_Category $updating New category object with updated data.
+	 */
+	private function update_existing_category( $existing, $updating ) {
+		if ( ! empty( $updating->get_name() ) ) {
+			$existing->set_name( $updating->get_name() );
+		}
+		if ( ! empty( $updating->get_description() ) ) {
+			$existing->set_description( $updating->get_description() );
+		}
 	}
 
 	/**
 	 * Removes a category.
 	 *
 	 * @since 0.1.0
-	 * @param string $slug Category slug.
-	 * @return bool True if category was removed, false otherwise.
+	 *
+	 * @param string|array|WP_Feature_Category $category Category to remove.
+	 * @return bool True if category was removed, false if category had features
 	 */
-	public function remove( $slug ) {
-		$category_obj = WP_Feature_Category::make( $slug );
+	public function remove( $category ) {
+		$category_obj = WP_Feature_Category::make( $category );
+
+		if ( ! $category_obj ) {
+			return new WP_Error(
+				'invalid_category',
+				__( 'Invalid category data provided.', 'wp-feature-api' )
+			);
+		}
+
 		$slug = $category_obj->get_slug();
 
 		if ( ! isset( $this->categories[ $slug ] ) ) {
@@ -103,10 +134,23 @@ final class WP_Feature_Categories {
 		}
 
 		$existing = $this->categories[ $slug ];
-		$existing->decrement_count();
-		if ( 0 === $existing->get_feature_count() ) {
-			unset( $this->categories[ $slug ] );
+		$feature_count = $existing->get_feature_count();
+
+		if ( $feature_count > 0 ) {
+			return false;
 		}
+
+		unset( $this->categories[ $slug ] );
+
+		/**
+		 * Fires after a category is removed.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param string $slug          The category slug that was removed.
+		 * @param int    $feature_count The number of features that were associated with this category.
+		 */
+		do_action( 'wp_feature_category_removed', $slug, $feature_count );
 
 		return true;
 	}
@@ -137,17 +181,11 @@ final class WP_Feature_Categories {
 			return;
 		}
 
-		/**
-		 * Filters the categories before they are registered.
-		 *
-		 * @since 0.1.0
-		 * @param array      $feature_categories The categories to be registered.
-		 * @param WP_Feature $feature           The feature being registered.
-		 */
-		$feature_categories = apply_filters( 'wp_feature_pre_register_categories', $feature_categories, $feature );
-
 		foreach ( $feature_categories as $category ) {
-			$this->add( $category );
+			$category_obj = $this->add( $category );
+			if ( $category_obj ) {
+				$category_obj->increment_count();
+			}
 		}
 	}
 
@@ -178,7 +216,10 @@ final class WP_Feature_Categories {
 		}
 
 		foreach ( $feature_categories as $category ) {
-			$this->remove( $category );
+			$result = $this->remove( $category );
+			if ( $result ) {
+				$category_obj->decrement_count();
+			}
 		}
 	}
 

--- a/includes/class-wp-feature-category.php
+++ b/includes/class-wp-feature-category.php
@@ -202,15 +202,19 @@ class WP_Feature_Category {
 	 * Creates a new category instance.
 	 *
 	 * @since 0.1.0
-	 * @param string|array $category Category data.
+	 * @param string|array|WP_Feature_Category $category Category data.
 	 * @return WP_Feature_Category|null Category instance or null on failure.
 	 */
 	public static function make( $category ) {
-		try {
-			return new self( $category );
-		} catch ( Exception $e ) {
-			return null;
+		if ( $category instanceof WP_Feature_Category ) {
+			return $category;
 		}
+
+		if ( is_string( $category ) || is_array( $category ) ) {
+			return new self( $category );
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/class-wp-feature-category.php
+++ b/includes/class-wp-feature-category.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * WP_Feature_Category class file.
+ *
+ * @package WordPress\Features_API
+ */
+
+/**
+ * Class WP_Feature_Category
+ *
+ * Represents a feature category in the WordPress Features API.
+ *
+ * @since 0.1.0
+ */
+class WP_Feature_Category {
+	/**
+	 * Category slug.
+	 *
+	 * @since 0.1.0
+	 * @var string
+	 */
+	private $slug;
+
+	/**
+	 * Category name.
+	 *
+	 * @since 0.1.0
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * Category description.
+	 *
+	 * @since 0.1.0
+	 * @var string
+	 */
+	private $description;
+
+	/**
+	 * Number of features in this category.
+	 *
+	 * @since 0.1.0
+	 * @var int
+	 */
+	private $feature_count = 0;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 0.1.0
+	 * @param string|array $category Category data.
+	 */
+	public function __construct( $category ) {
+		if ( is_string( $category ) ) {
+			$this->from_string( $category );
+		} elseif ( is_array( $category ) ) {
+			$this->from_array( $category );
+		}
+	}
+
+	/**
+	 * Gets the schema for the category.
+	 *
+	 * @since 0.1.0
+	 * @return array
+	 */
+	public static function get_schema() {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'feature-category',
+			'type'       => 'object',
+			'properties' => array(
+				'slug'          => array(
+					'description' => __( 'Unique identifier for the category.', 'wp-feature-api' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'name'          => array(
+					'description' => __( 'Display name for the category.', 'wp-feature-api' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'description'   => array(
+					'description' => __( 'Description of the category.', 'wp-feature-api' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'feature_count' => array(
+					'description' => __( 'Number of features in this category.', 'wp-feature-api' ),
+					'type'        => 'integer',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Gets the category slug.
+	 *
+	 * @since 0.1.0
+	 * @return string
+	 */
+	public function get_slug() {
+		return $this->slug;
+	}
+
+	/**
+	 * Gets the category name.
+	 *
+	 * @since 0.1.0
+	 * @return string
+	 */
+	public function get_name() {
+		return $this->name;
+	}
+
+	/**
+	 * Sets the category name.
+	 *
+	 * @since 0.1.0
+	 * @param string $name Category name.
+	 * @return void
+	 */
+	public function set_name( $name ) {
+		$this->name = sanitize_text_field( $name );
+	}
+
+	/**
+	 * Gets the category description.
+	 *
+	 * @since 0.1.0
+	 * @return string
+	 */
+	public function get_description() {
+		return $this->description;
+	}
+
+	/**
+	 * Sets the category description.
+	 *
+	 * @since 0.1.0
+	 * @param string $description Category description.
+	 * @return void
+	 */
+	public function set_description( $description ) {
+		$this->description = wp_kses_post( $description );
+	}
+
+	/**
+	 * Gets the feature count.
+	 *
+	 * @since 0.1.0
+	 * @return int
+	 */
+	public function get_feature_count() {
+		return $this->feature_count;
+	}
+
+	/**
+	 * Increments the feature count.
+	 *
+	 * @since 0.1.0
+	 * @return void
+	 */
+	public function increment_count() {
+		++$this->feature_count;
+	}
+
+	/**
+	 * Decrements the feature count.
+	 *
+	 * @since 0.1.0
+	 * @return void
+	 */
+	public function decrement_count() {
+		if ( $this->feature_count > 0 ) {
+			--$this->feature_count;
+		}
+	}
+
+	/**
+	 * Converts the category to an array.
+	 *
+	 * @since 0.1.0
+	 * @return array
+	 */
+	public function to_array() {
+		return array(
+			'slug'          => $this->slug,
+			'name'          => $this->name,
+			'description'   => $this->description,
+			'feature_count' => $this->feature_count,
+		);
+	}
+
+	/**
+	 * Creates a new category instance.
+	 *
+	 * @since 0.1.0
+	 * @param string|array $category Category data.
+	 * @return WP_Feature_Category|null Category instance or null on failure.
+	 */
+	public static function make( $category ) {
+		try {
+			return new self( $category );
+		} catch ( Exception $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Creates a category instance from string.
+	 *
+	 * @since 0.1.0
+	 * @param string $category Category slug.
+	 */
+	private function from_string( $category ) {
+		$this->slug = sanitize_key( $category );
+		$this->name = ucwords( str_replace( array( '-', '_' ), ' ', $this->slug ) );
+		$this->description = '';
+	}
+
+	/**
+	 * Creates a category instance from array.
+	 *
+	 * @since 0.1.0
+	 * @param array $category Category data.
+	 */
+	private function from_array( $category ) {
+		if ( ! isset( $category['slug'] ) ) {
+			return;
+		}
+
+		$this->slug = sanitize_key( $category['slug'] );
+		$this->name = isset( $category['name'] )
+			? sanitize_text_field( $category['name'] )
+			: ucwords( str_replace( array( '-', '_' ), ' ', $this->slug ) );
+		$this->description = isset( $category['description'] )
+			? wp_kses_post( $category['description'] )
+			: '';
+	}
+}

--- a/includes/class-wp-feature-query.php
+++ b/includes/class-wp-feature-query.php
@@ -13,7 +13,6 @@
  * @since 0.1.0
  */
 class WP_Feature_Query {
-
 	/**
 	 * The query arguments.
 	 *

--- a/includes/class-wp-feature-registry.php
+++ b/includes/class-wp-feature-registry.php
@@ -251,6 +251,17 @@ class WP_Feature_Registry {
 	}
 
 	/**
+	 * Gets a feature category by its ID.
+	 *
+	 * @since 0.1.0
+	 * @param string $id The category ID.
+	 * @return WP_Feature_Category|null The category if found, null otherwise.
+	 */
+	public function get_category( $id ) {
+		return $this->categories->get( $id );
+	}
+
+	/**
 	 * Removes a feature from the repository and cache.
 	 *
 	 * @since 0.1.0

--- a/includes/class-wp-feature-registry.php
+++ b/includes/class-wp-feature-registry.php
@@ -40,11 +40,12 @@ class WP_Feature_Registry {
 	private $features = array();
 
 	/**
-	 * @todo: keep track of categories
-	 * this will be important for use in inference using an LLM to narrow down the features by category.
-	 * should categories contain descriptions?
+	 * The categories collection.
+	 *
+	 * @since 0.1.0
+	 * @var WP_Feature_Categories
 	 */
-	private $categories = array();
+	private $categories = null;
 
 	/**
 	 * Private constructor to prevent direct instantiation.
@@ -55,6 +56,8 @@ class WP_Feature_Registry {
 	private function __construct() {
 		require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/interface-wp-feature-repository.php';
 		require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-repository-memory.php';
+		require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-category.php';
+		require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-categories.php';
 
 		$default_repository = new WP_Feature_Repository_Memory();
 		$repository = apply_filters( 'wp_feature_repository', $default_repository );
@@ -73,6 +76,7 @@ class WP_Feature_Registry {
 		}
 
 		$this->repository = $repository;
+		$this->categories = new WP_Feature_Categories();
 		$this->cache_clear();
 	}
 
@@ -126,6 +130,8 @@ class WP_Feature_Registry {
 		 */
 		do_action( 'wp_feature_registered', $feature );
 
+		$this->categories->update_for_feature( $feature );
+
 		return true;
 	}
 
@@ -155,6 +161,8 @@ class WP_Feature_Registry {
 		if ( ! $removed ) {
 			return false;
 		}
+
+		$this->categories->remove_for_feature( $feature_obj );
 
 		/**
 		 * Fires after a feature is unregistered.
@@ -219,6 +227,27 @@ class WP_Feature_Registry {
 		}
 
 		return $this->repository->query( $query );
+	}
+
+	/**
+	 * Gets all registered categories.
+	 *
+	 * @since 0.1.0
+	 * @return array Array of categories with their descriptions and feature counts.
+	 */
+	public function get_categories() {
+		$categories = array();
+		foreach ( $this->categories->get_all() as $category ) {
+			$categories[ $category->get_slug() ] = $category->to_array();
+		}
+
+		/**
+		 * Filters the complete list of registered categories.
+		 *
+		 * @since 0.1.0
+		 * @param array $categories Array of registered categories.
+		 */
+		return apply_filters( 'wp_feature_categories', $categories );
 	}
 
 	/**

--- a/includes/default-wp-features.php
+++ b/includes/default-wp-features.php
@@ -12,6 +12,33 @@
  * @return void
  */
 function wp_feature_api_register_core_features() {
+	add_filter(
+		'wp_feature_default_categories',
+		function ( $categories ) {
+			return array_merge(
+				$categories,
+				array(
+					'core' => array(
+						'name'        => 'Core',
+						'description' => 'Core features of WordPress available everywhere in the admin.',
+					),
+					'post' => array(
+						'name'        => 'Posts',
+						'description' => 'Features related to posts.',
+					),
+					'user' => array(
+						'name'        => 'Users',
+						'description' => 'Features related to users.',
+					),
+					'rest' => array(
+						'name'        => 'REST API',
+						'description' => 'Features related to the REST API.',
+					),
+				)
+			);
+		}
+	);
+
 	$core_features = array(
 		/**
 		 * Posts

--- a/includes/rest-api/class-wp-rest-feature-controller.php
+++ b/includes/rest-api/class-wp-rest-feature-controller.php
@@ -80,6 +80,20 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 			)
 		);
 
+		// Register GET endpoint for retrieving feature categories.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/categories',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_categories' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'schema'              => WP_Feature_Category::get_schema(),
+				),
+			)
+		);
+
 		// Get features after they've been registered.
 		$features = wp_feature_registry()->get();
 		foreach ( $features as $feature ) {
@@ -500,5 +514,18 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 				'schema' => array( $feature, 'get_output_schema' ),
 			)
 		);
+	}
+
+	/**
+	 * Retrieves the feature categories.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_categories( $request ) {
+		$categories = wp_feature_registry()->get_categories();
+		return rest_ensure_response( $categories );
 	}
 }

--- a/includes/rest-api/class-wp-rest-feature-controller.php
+++ b/includes/rest-api/class-wp-rest-feature-controller.php
@@ -94,6 +94,28 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 			)
 		);
 
+		// Register GET endpoint for retrieving a single feature category.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/categories/(?P<id>[\w-]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_category' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'description'       => __( 'Unique identifier for the feature category.', 'wp-feature-api' ),
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+							'validate_callback' => 'rest_validate_request_arg',
+						),
+					),
+					'schema' => WP_Feature_Category::get_schema(),
+				),
+			)
+		);
+
 		// Get features after they've been registered.
 		$features = wp_feature_registry()->get();
 		foreach ( $features as $feature ) {
@@ -527,5 +549,23 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 	public function get_categories( $request ) {
 		$categories = wp_feature_registry()->get_categories();
 		return rest_ensure_response( $categories );
+	}
+
+	/**
+	 * Retrieves a single feature category.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_category( $request ) {
+		$id = $request['id'];
+		$category = wp_feature_registry()->get_category( $id );
+
+		if ( ! $category ) {
+			return new WP_Error( 'rest_feature_category_not_found', __( 'Feature category not found.', 'wp-feature-api' ), array( 'status' => 404 ) );
+		}
+		return rest_ensure_response( $category->to_array() );
 	}
 }


### PR DESCRIPTION
This PR adds category management for registered features. It includes a name and description and adds an endpoint so that these can be queried. This is useful for an LLM to determine a category before scoping features to it. 

We can provide some full category objects up front with descriptions, and they'll be reused when attaching by slug only in a feature. Or the feature can register a full category that will update the name and description if provided. 

We're also keeping track of the feature/category count. Just seemed useful