### PR TITLE
Fix/stricter schema encoding

### DIFF
--- a/includes/class-wp-feature-categories.php
+++ b/includes/class-wp-feature-categories.php
@@ -218,7 +218,7 @@ final class WP_Feature_Categories {
 		foreach ( $feature_categories as $category ) {
 			$result = $this->remove( $category );
 			if ( $result ) {
-				$category_obj->decrement_count();
+				$category->decrement_count();
 			}
 		}
 	}

--- a/includes/class-wp-feature-schema-adapter.php
+++ b/includes/class-wp-feature-schema-adapter.php
@@ -13,7 +13,7 @@
  *
  * @since 0.1.0
  */
-class WP_Feature_Schema_Transformer {
+class WP_Feature_Schema_Adapter {
 	/**
 	 * The schema to transform.
 	 *

--- a/includes/class-wp-feature-schema-transformer.php
+++ b/includes/class-wp-feature-schema-transformer.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * WP_Feature_Schema_Transformer class file.
+ *
+ * @package WordPress\Features_API
+ */
+
+/**
+ * Class WP_Feature_Schema_Transformer
+ *
+ * Handles transformation of JSON schemas into OpenAI-compatible versions.
+ * To handle other provider JSON Schema specifications, create a subclass and override the `transform` method.
+ *
+ * @since 0.1.0
+ */
+class WP_Feature_Schema_Transformer {
+	/**
+	 * The schema to transform.
+	 *
+	 * @since 0.1.0
+	 * @var array
+	 */
+	private $schema;
+
+	/**
+	 * The transformation rules to apply.
+	 *
+	 * @since 0.1.0
+	 * @var array
+	 */
+	private $rules;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 0.1.0
+	 * @param array $schema The schema to transform.
+	 * @param array $rules  The transformation rules to apply.
+	 */
+	public function __construct( $schema, $rules = array() ) {
+		$this->schema = $schema;
+		$this->rules = wp_parse_args(
+			$rules,
+			array(
+				'remove_unsupported_properties' => array(
+					'format',
+					'validate_callback',
+					'sanitize_callback',
+					'default',
+				),
+				'add_required_properties' => array( $this, 'process_required_properties' ),
+				'strict_object_encoding' => true,
+			)
+		);
+	}
+
+	/**
+	 * Creates a new WP_Feature_Schema_Transformer instance.
+	 *
+	 * @since 0.1.0
+	 * @param string|null $transformer_class The transformer class to use, must extend WP_Feature_Schema_Transformer.
+	 * @param array       $schema The schema to transform.
+	 * @param array       $rules The transformation rules to apply.
+	 * @return WP_Feature_Schema_Transformer The new transformer instance.
+	 */
+	public static function make( $transformer_class, $schema, $rules = array() ) {
+		if ( null !== $transformer_class ) {
+			if ( ! is_string( $transformer_class ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: %s: Transformer class name */
+						__( 'The WP_Feature_Schema_Transformer subclass must be a string. Received: %s', 'wp-feature-api' ),
+						gettype( $transformer_class )
+					),
+					'0.1.0'
+				);
+				return new self( $schema, $rules );
+			}
+
+			if ( ! class_exists( $transformer_class ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: %s: Transformer class name */
+						__( 'The WP_Feature_Schema_Transformer subclass %s does not exist.', 'wp-feature-api' ),
+						$transformer_class
+					),
+					'0.1.0'
+				);
+				return new self( $schema, $rules );
+			}
+
+			if ( ! is_subclass_of( $transformer_class, __CLASS__ ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: %1$s: Transformer class name, %2$s: Parent class name */
+						__( 'The WP_Feature_Schema_Transformer subclass %1$s must extend %2$s.', 'wp-feature-api' ),
+						$transformer_class,
+						__CLASS__
+					),
+					'0.1.0'
+				);
+				return new self( $schema, $rules );
+			}
+
+			return new $transformer_class( $schema, $rules );
+		}
+
+		return new self( $schema, $rules );
+	}
+
+	/**
+	 * Transforms the schema according to the configured rules.
+	 *
+	 * @since 0.1.0
+	 * @return array The transformed schema.
+	 */
+	public function transform() {
+		if ( ! is_array( $this->schema ) ) {
+			return $this->schema;
+		}
+
+		$transformed = $this->schema;
+
+		if ( $this->rules['remove_unsupported_properties'] ) {
+			$transformed = $this->remove_unsupported_properties( $transformed );
+		}
+
+		if ( $this->rules['add_required_properties'] ) {
+			$transformed = $this->add_required_properties( $transformed );
+		}
+
+		if ( $this->rules['strict_object_encoding'] ) {
+			$transformed = $this->strict_object_encoding( $transformed );
+		}
+
+		return $transformed;
+	}
+
+	/**
+	 * Strips the unsupported properties from object properties.
+	 *
+	 * @since 0.1.0
+	 * @param array $data The data to strip unsupported properties from.
+	 * @return array The data with unsupported properties stripped.
+	 */
+	private function remove_unsupported_properties( $data ) {
+		if ( ! is_array( $data ) ) {
+			return $data;
+		}
+
+		// Remove unsupported properties from the current object.
+		foreach ( $this->rules['remove_unsupported_properties'] as $unsupported_prop ) {
+			unset( $data[ $unsupported_prop ] );
+		}
+
+		// Recursively process nested structures.
+		foreach ( $data as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$data[ $key ] = $this->remove_unsupported_properties( $value );
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Ensures required object properties include 'additionalProperties' set to false.
+	 *
+	 * @since 0.1.0
+	 * @param array $data The data to ensure properties for.
+	 * @return array The data with required properties.
+	 */
+	private function add_required_properties( $data ) {
+		if ( ! is_array( $data ) ) {
+			return $data;
+		}
+
+		// Add required properties to the current object.
+		if ( isset( $data['properties'] ) ) {
+			$data = call_user_func( $this->rules['add_required_properties'], $data );
+		}
+
+		// Recursively process nested structures.
+		foreach ( $data as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$data[ $key ] = $this->add_required_properties( $value );
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Enforces actual objects for empty arrays of type 'object'.
+	 *
+	 * @since 0.1.0
+	 * @param array $data The data to encode.
+	 * @return array The encoded data.
+	 */
+	private function strict_object_encoding( $data ) {
+		if ( ! is_array( $data ) ) {
+			return $data;
+		}
+
+		foreach ( $data as $key => $value ) {
+			if ( ! is_array( $value ) ) {
+				continue;
+			}
+
+			if (
+				isset( $value['type'] ) &&
+				isset( $value['properties'] ) &&
+				'object' === $value['type'] &&
+				empty( $value['properties'] )
+			) {
+				$value['properties'] = new \stdClass();
+			} else {
+				$value = $this->strict_object_encoding( $value );
+			}
+
+			$data[ $key ] = $value;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Processes and adds required properties to a schema object.
+	 *
+	 * @since 0.1.0
+	 * @param array $data The schema data to process.
+	 * @return array The processed schema data.
+	 */
+	private function process_required_properties( $data ) {
+		if ( ! isset( $data['properties'] ) ) {
+			return $data;
+		}
+
+		$required = array_keys( $data['properties'] );
+		foreach ( $data['properties'] as $property_key => $property_value ) {
+			if ( isset( $property_value['required'] ) && ! $property_value['required'] ) {
+				unset( $required[ $property_key ] );
+			}
+			unset( $data['properties'][ $property_key ]['required'] );
+		}
+
+		$data['additionalProperties'] = false;
+		$data['required'] = $required;
+
+		return $data;
+	}
+}

--- a/includes/class-wp-feature.php
+++ b/includes/class-wp-feature.php
@@ -189,7 +189,7 @@ class WP_Feature implements \JsonSerializable {
 	 * @param array  $args The feature arguments.
 	 */
 	public function __construct( $id, $args = array() ) {
-		require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-schema-transformer.php';
+		require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-schema-adapter.php';
 
 		if ( empty( $id ) || ! is_string( $id ) ) {
 			_doing_it_wrong(
@@ -337,7 +337,7 @@ class WP_Feature implements \JsonSerializable {
 	 */
 	public function get_input_schema() {
 		$transformer_class = apply_filters( 'wp_feature_input_schema_transformer', null, $this );
-		$transformer = WP_Feature_Schema_Transformer::make( $transformer_class, $this->input_schema );
+		$transformer = WP_Feature_Schema_Adapter::make( $transformer_class, $this->input_schema );
 		return $transformer->transform();
 	}
 
@@ -349,7 +349,7 @@ class WP_Feature implements \JsonSerializable {
 	 */
 	public function get_output_schema() {
 		$transformer_class = apply_filters( 'wp_feature_output_schema_transformer', null, $this );
-		$transformer = WP_Feature_Schema_Transformer::make( $transformer_class, $this->output_schema );
+		$transformer = WP_Feature_Schema_Adapter::make( $transformer_class, $this->output_schema );
 		return $transformer->transform();
 	}
 

--- a/includes/class-wp-feature.php
+++ b/includes/class-wp-feature.php
@@ -336,7 +336,7 @@ class WP_Feature implements \JsonSerializable {
 	 * @return array The feature input schema.
 	 */
 	public function get_input_schema() {
-		$transformer_class = apply_filters( 'wp_feature_input_schema_transformer', null, $this );
+		$transformer_class = apply_filters( 'wp_feature_input_schema_adapter', null, $this );
 		$transformer = WP_Feature_Schema_Adapter::make( $transformer_class, $this->input_schema );
 		return $transformer->transform();
 	}
@@ -348,7 +348,7 @@ class WP_Feature implements \JsonSerializable {
 	 * @return array The feature output schema.
 	 */
 	public function get_output_schema() {
-		$transformer_class = apply_filters( 'wp_feature_output_schema_transformer', null, $this );
+		$transformer_class = apply_filters( 'wp_feature_output_schema_adapter', null, $this );
 		$transformer = WP_Feature_Schema_Adapter::make( $transformer_class, $this->output_schema );
 		return $transformer->transform();
 	}

--- a/includes/class-wp-feature.php
+++ b/includes/class-wp-feature.php
@@ -182,39 +182,6 @@ class WP_Feature implements \JsonSerializable {
 	private $location;
 
 	/**
-	 * Enforces actual objects for empty arrays of type 'object'.
-	 *
-	 * @since 0.1.0
-	 * @param mixed $data The data to encode.
-	 * @return mixed The encoded data.
-	 */
-	private function enforce_type_encoding( $data ) {
-		if ( ! is_array( $data ) ) {
-			return $data;
-		}
-
-		foreach ( $data as $key => $value ) {
-			if ( ! is_array( $value ) ) {
-				continue;
-			}
-
-			if (
-				isset( $value['type'] ) &&
-				'object' === $value['type'] &&
-				empty( $value['properties'] )
-			) {
-				$value['properties'] = new \stdClass();
-			} else {
-				$value = $this->enforce_type_encoding( $value );
-			}
-
-			$data[ $key ] = $value;
-		}
-
-		return $data;
-	}
-
-	/**
 	 * Constructor.
 	 *
 	 * @since 0.1.0
@@ -222,6 +189,8 @@ class WP_Feature implements \JsonSerializable {
 	 * @param array  $args The feature arguments.
 	 */
 	public function __construct( $id, $args = array() ) {
+		require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-schema-transformer.php';
+
 		if ( empty( $id ) || ! is_string( $id ) ) {
 			_doing_it_wrong(
 				__METHOD__,
@@ -367,7 +336,9 @@ class WP_Feature implements \JsonSerializable {
 	 * @return array The feature input schema.
 	 */
 	public function get_input_schema() {
-		return $this->enforce_type_encoding( $this->input_schema );
+		$transformer_class = apply_filters( 'wp_feature_input_schema_transformer', null, $this );
+		$transformer = WP_Feature_Schema_Transformer::make( $transformer_class, $this->input_schema );
+		return $transformer->transform();
 	}
 
 	/**
@@ -377,7 +348,9 @@ class WP_Feature implements \JsonSerializable {
 	 * @return array The feature output schema.
 	 */
 	public function get_output_schema() {
-		return $this->enforce_type_encoding( $this->output_schema );
+		$transformer_class = apply_filters( 'wp_feature_output_schema_transformer', null, $this );
+		$transformer = WP_Feature_Schema_Transformer::make( $transformer_class, $this->output_schema );
+		return $transformer->transform();
 	}
 
 	/**

--- a/includes/class-wp-feature.php
+++ b/includes/class-wp-feature.php
@@ -367,8 +367,7 @@ class WP_Feature implements \JsonSerializable {
 	 * @return array The feature input schema.
 	 */
 	public function get_input_schema() {
-		$schema = $this->enforce_type_encoding( $this->input_schema );
-		return $schema;
+		return $this->enforce_type_encoding( $this->input_schema );
 	}
 
 	/**

--- a/includes/class-wp-feature.php
+++ b/includes/class-wp-feature.php
@@ -182,6 +182,39 @@ class WP_Feature implements \JsonSerializable {
 	private $location;
 
 	/**
+	 * Enforces actual objects for empty arrays of type 'object'.
+	 *
+	 * @since 0.1.0
+	 * @param mixed $data The data to encode.
+	 * @return mixed The encoded data.
+	 */
+	private function enforce_type_encoding( $data ) {
+		if ( ! is_array( $data ) ) {
+			return $data;
+		}
+
+		foreach ( $data as $key => $value ) {
+			if ( ! is_array( $value ) ) {
+				continue;
+			}
+
+			if (
+				isset( $value['type'] ) &&
+				'object' === $value['type'] &&
+				empty( $value['properties'] )
+			) {
+				$value['properties'] = new \stdClass();
+			} else {
+				$value = $this->enforce_type_encoding( $value );
+			}
+
+			$data[ $key ] = $value;
+		}
+
+		return $data;
+	}
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 0.1.0
@@ -334,7 +367,8 @@ class WP_Feature implements \JsonSerializable {
 	 * @return array The feature input schema.
 	 */
 	public function get_input_schema() {
-		return $this->input_schema;
+		$schema = $this->enforce_type_encoding( $this->input_schema );
+		return $schema;
 	}
 
 	/**
@@ -344,7 +378,7 @@ class WP_Feature implements \JsonSerializable {
 	 * @return array The feature output schema.
 	 */
 	public function get_output_schema() {
-		return $this->output_schema;
+		return $this->enforce_type_encoding( $this->output_schema );
 	}
 
 	/**
@@ -617,7 +651,7 @@ class WP_Feature implements \JsonSerializable {
 		 * @param array      $input        The input to validate.
 		 * @param WP_Feature $feature      The feature object.
 		 */
-		$schema = apply_filters( 'wp_feature_input_schema_validate', $this->input_schema, $input, $this );
+		$schema = apply_filters( 'wp_feature_input_schema_validate', $this->get_input_schema(), $input, $this );
 		$schema = apply_filters( $this->get_filter_id() . '_input_schema_validate', $schema, $input, $this );
 
 		return rest_validate_value_from_schema( $input, $schema );
@@ -659,9 +693,8 @@ class WP_Feature implements \JsonSerializable {
 			'type'          => $this->type,
 			'meta'          => $this->meta,
 			'categories'    => $this->categories,
-			'input_schema'  => $this->input_schema,
-			'output_schema' => $this->output_schema,
-			'permissions'   => $this->permissions,
+			'input_schema'  => $this->get_input_schema(),
+			'output_schema' => $this->get_output_schema(),
 			'location'      => $this->get_location(),
 		);
 
@@ -684,7 +717,7 @@ class WP_Feature implements \JsonSerializable {
 	 * @since 0.1.0
 	 * @return array The feature as a JSON serializable array.
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return $this->to_array();
 	}
 
@@ -786,7 +819,7 @@ class WP_Feature implements \JsonSerializable {
 			sprintf(
 				/* translators: %1$s: Feature name, %2$s: HTTP method */
 				__( 'REST API alias of feature (%1$s) does not support the method %2$s.', 'wp-feature-api' ),
-				$feature->get_id(),
+				$this->get_id(),
 				$method
 			),
 			array( 'status' => 405 )


### PR DESCRIPTION
## Problem

When using the schema for structured tool calls with OpenAI, empty arrays for object types in the schema were encoded as json arrays:

```php
[
    'meta' => [
        'type' => 'object',
        'properties' => array()
    ]
]
```
Resulting in 
```json
{
  "meta": {
    "type": "object",
    "properties": []
  }
}
```
Which is invalid JSON schema and the call fails. 

## Fix

This PR forces empty arrays that have a schema type of object to be redefined as stdClass so they're encoded properly. 

## Testing

`GET: /wp-json/wp/v2/features`

Note that `[resource-posts].input_schema.meta.properties` is a JSON object `{}` and not `[]` as previously.