### PR TITLE
Fix: Make features API available on every WordPress screen.

### DIFF
--- a/wp-feature-api.php
+++ b/wp-feature-api.php
@@ -62,7 +62,8 @@ function wp_feature_api_enqueue_admin_scripts() {
 	if ( ! is_admin() ) {
 		return;
 	}
-	wp_enqueue_script( 'wp_feature_api_script', WP_FEATURE_API_PLUGIN_URL . 'build/index.js', array(), '1.0', true );
+	$assets = require WP_FEATURE_API_PLUGIN_DIR . 'build/index.asset.php';
+	wp_enqueue_script( 'wp_feature_api_script', WP_FEATURE_API_PLUGIN_URL . 'build/index.js', $assets['dependencies'], $assets['version'], true );
 }
 
 /**


### PR DESCRIPTION
This PR makes sure the dependencies of the features API are properly passed to the enque function. This makes the features API available for use on any admin screen.

## Testing
Navigate to the main wp-admin page, posts list, and other sections.
On each one, open the browser console and paste `await wp.data.resolveSelect('feature-api').getRegisteredFeatures();`, verify features are returned without any error.