### PR TITLE
Fix: Impossible to execute tools and resources with parameters.

### DIFF
--- a/includes/class-wp-feature.php
+++ b/includes/class-wp-feature.php
@@ -425,10 +425,11 @@ class WP_Feature implements \JsonSerializable {
 	 * Runs the feature.
 	 *
 	 * @since 0.1.0
-	 * @param array $context The context to run the feature with.
+	 * @param object $rest_request The context to run the feature with.
 	 * @return mixed The result of running the feature.
 	 */
-	public function run( $context = array() ) {
+	public function run( $rest_request ) {
+		$context = $rest_request->get_param( 'context' );
 		/**
 		 * Filters the context before running a feature.
 		 *
@@ -473,7 +474,6 @@ class WP_Feature implements \JsonSerializable {
 		do_action( $this->get_filter_id() . '_before_run', $context, $this );
 		// Run the feature callback.
 
-		$rest_request = new WP_REST_Request( $this->get_rest_method(), $context );
 		$result = call_user_func( $this->callback, $rest_request );
 
 		/**

--- a/includes/rest-api/class-wp-rest-feature-controller.php
+++ b/includes/rest-api/class-wp-rest-feature-controller.php
@@ -494,8 +494,7 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 				array(
 					'methods'             => $feature->get_rest_method(),
 					'callback'            => function ( $request ) use ( $feature ) {
-						$context = $request->get_param( 'context' );
-						$result = $feature->run( $context );
+						$result = $feature->run( $request );
 						return rest_ensure_response( $result );
 					},
 					'permission_callback' => array( $feature, 'get_permission_callback' ),


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-feature-api/issues/12


## Testing
Paste `await wp.apiFetch( { path: 'wp/v2/features/tool-posts/run', method: 'POST', data: {title: {raw: 'ok' }, content: {raw: 'a' } } } );` and verify a new post is created.

Paste `await wp.apiFetch( { path: 'wp/v2/features/resource-posts/run', method: 'GET' } );`and verify posts are returned (11 that is a bug that we still need to fix).

Paste `await wp.apiFetch( { path: 'wp/v2/features/resource-posts/run?per_page=20', method: 'GET' } );` and verify 20 posts are returned as expected.