### PR TITLE
Fix demo loading on a fresh site

### DIFF
--- a/demo/wp-feature-api-demo/includes/Agent/BasicAgent.php
+++ b/demo/wp-feature-api-demo/includes/Agent/BasicAgent.php
@@ -130,7 +130,7 @@ class BasicAgent {
 			];
 
 			// additionalProperties is always present. So 1 is considered empty.
-			if ( count( $parameters ) > 1 ) {
+			if ( is_array( $parameters ) && count( $parameters ) > 1 ) {
 				$function['parameters'] = $parameters;
 			} else {
 				$function['parameters'] = [

--- a/demo/wp-feature-api-demo/includes/BootstrapAssets.php
+++ b/demo/wp-feature-api-demo/includes/BootstrapAssets.php
@@ -21,12 +21,15 @@ class BootstrapAssets {
             true
         );
 
-		wp_enqueue_style(
-			'wp-components-css',
-			includes_url('css/dist/components/style.min.css'),
-			array(),
-			false
-		);
+		// Only enqueue wp-components CSS if it's not already loaded by core (e.g., on editor screens), otherwise things will not render correctly.
+		if ( ! wp_style_is( 'wp-components', 'enqueued' ) ) {
+			wp_enqueue_style(
+				'wp-components-css',
+				includes_url('css/dist/components/style.min.css'),
+				array(),
+				false
+			);
+		}
 
         wp_enqueue_style(
             'wp-feature-api-demo',

--- a/demo/wp-feature-api-demo/includes/RegisterFeatures.php
+++ b/demo/wp-feature-api-demo/includes/RegisterFeatures.php
@@ -57,7 +57,7 @@ class RegisterFeatures {
 		);
 	}
 
-	private function site_info_callback( $input ) {
+	public function site_info_callback( $input ) {
 		return array(
 			'name'        => get_bloginfo( 'name' ),
 			'description' => get_bloginfo( 'description' ),


### PR DESCRIPTION
This PR fixes a few issues I had while setting up and testing the demo plugin on a fresh site:

1. Adds an array type check to prevent errors with non-array values

If the returned list of tools is empty/null, `tools_from_features` can return the following:

```
[08-Apr-2025 15:45:31 UTC] PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in /Users/emdash/Dev/wp-feature-api/demo/wp-feature-api-demo/includes/Agent/BasicAgent.php:133
Stack trace:
#0 /Users/emdash/Dev/wp-feature-api/demo/wp-feature-api-demo/includes/Agent/BasicAgent.php(133): count(NULL)
#1 [internal function]: A8C\WpFeatureApiDemo\Agent\BasicAgent->A8C\WpFeatureApiDemo\Agent\{closure}(Object(WP_Feature))
#2 /Users/emdash/Dev/wp-feature-api/demo/wp-feature-api-demo/includes/Agent/BasicAgent.php(123): array_map(Object(Closure), Array)
#3 /Users/emdash/Dev/wp-feature-api/demo/wp-feature-api-demo/includes/Agent/BasicAgent.php(65): A8C\WpFeatureApiDemo\Agent\BasicAgent->tools_from_features(Array)
#4 /Users/emdash/Dev/wp-feature-api/demo/wp-feature-api-demo/includes/Agent/BasicAgent.php(76): A8C\WpFeatureApiDemo\Agent\BasicAgent->get_tools()
#5 /Users/emdash/Dev/wp-feature-api/demo/wp-feature-api-demo/includes/Agent/BasicAgent.php(86): A8C\WpFeatureApiDemo\Agent\BasicAgent->llm_request('You are a helpf...')
#6 /Users/emdash/Dev/wp-feature-api/demo/wp-feature-api-demo/includes/Agent/BasicAgent.php(48): A8C\WpFeatureApiDemo\Agent\BasicAgent->make_response_or_feature_call()
#7 /Users/emdash/Dev/wp-feature-api/demo/wp-feature-api-demo/includes/ChatController.php(49): A8C\WpFeatureApiDemo\Agent\BasicAgent->run()
#8 /var/www/html/wp-includes/rest-api/class-wp-rest-server.php(1292): A8C\WpFeatureApiDemo\ChatController->handle_chat_request(Object(WP_REST_Request))
#9 /var/www/html/wp-includes/rest-api/class-wp-rest-server.php(1125): WP_REST_Server->respond_to_request(Object(WP_REST_Request), '/wp/v2/demo-cha...', Array, NULL)
#10 /var/www/html/wp-includes/rest-api/class-wp-rest-server.php(439): WP_REST_Server->dispatch(Object(WP_REST_Request))
#11 /var/www/html/wp-includes/rest-api.php(449): WP_REST_Server->serve_request('/wp/v2/demo-cha...')
#12 /var/www/html/wp-includes/class-wp-hook.php(324): rest_api_loaded(Object(WP))
#13 /var/www/html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#14 /var/www/html/wp-includes/plugin.php(565): WP_Hook->do_action(Array)
#15 /var/www/html/wp-includes/class-wp.php(418): do_action_ref_array('parse_request', Array)
#16 /var/www/html/wp-includes/class-wp.php(813): WP->parse_request('')
#17 /var/www/html/wp-includes/functions.php(1336): WP->main('')
#18 /var/www/html/wp-blog-header.php(16): wp()
#19 /var/www/html/index.php(17): require('/var/www/html/w...')
#20 {main}
  thrown in /Users/emdash/Dev/wp-feature-api/demo/wp-feature-api-demo/includes/Agent/BasicAgent.php on line 133
[08-Apr-2025 15:47:43 UTC] PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in /Users/emdash/Dev/wp-feature-api/demo/wp-feature-api-demo/includes/Agent/BasicAgent.php:133
```

2. Changes site_info_callback from private to public

The `site_info` tool will not execute as a private/protected method so the response would come back empty.

3. Fixes asset loading in Gutenberg

We were trying to load the `wp-components` CSS twice on the editor screen which was preventing it from displaying correctly.

## Testing Instructions
1. Open the demo chat box
2. Ask the demo for site info
3. See that a valid response comes back
4. Go to the post editor and verify chat loads there too

<img width="371" alt="Screenshot 2025-04-08 at 12 20 53 PM" src="https://github.com/user-attachments/assets/7579dd3f-081f-4b32-b473-604f220b9395" />
