### PR TITLE
Fix: WP_Feature_Schema_Adapter executes rules with false.

### DIFF
--- a/includes/class-wp-feature-schema-adapter.php
+++ b/includes/class-wp-feature-schema-adapter.php
@@ -205,7 +205,7 @@ class WP_Feature_Schema_Adapter {
 
 		foreach ( array_keys( $this->rules ) as $rule_name ) {
 			$rule_method = 'rule_' . $rule_name;
-			if ( method_exists( $this, $rule_method ) ) {
+			if ( method_exists( $this, $rule_method ) && true === $this->rules[ $rule_name ] ) {
 				$this->transformed_schema = call_user_func( array( $this, $rule_method ), $rule_name, $this->transformed_schema );
 			}
 		}


### PR DESCRIPTION
Currently we are executing all rules even the ones set to false. This PR fixes the issue.

## Testing

- Execute await wp.apiFetch( { path: 'wp/v2/features' }); on the browser console and verify all features are part of the required array on the input schema.
- On /wp-feature-api/includes/class-wp-feature-schema-adapter.php change 				`'all_fields_required'         => true,` to `'all_fields_required'         => false,`.
- Execute await wp.apiFetch( { path: 'wp/v2/features' }); on the browser console and not all features are part of the required array.
