### PR TITLE
Fix: Impossible to execute tools with parameters.

### DIFF
--- a/includes/class-wp-feature-schema-adapter.php
+++ b/includes/class-wp-feature-schema-adapter.php
@@ -105,7 +105,7 @@ class WP_Feature_Schema_Adapter {
 				 * Description: To use Structured Outputs, all fields or function parameters must be specified as required.
 				 * Although all fields must be required (and the model will return a value for each parameter), it is possible to emulate an optional parameter by using a union type with null.
 				 */
-				'all_fields_required'         => true,
+				'all_fields_required'         => false,
 				/**
 				 * Name: additionalProperties
 				 * Description: false must always be set in objects additionalProperties controls whether it is allowable for an object to contain additional keys / values that were not defined in the JSON Schema.

--- a/includes/class-wp-feature.php
+++ b/includes/class-wp-feature.php
@@ -433,7 +433,7 @@ class WP_Feature implements \JsonSerializable {
 	 * @param array $context The context to run the feature with.
 	 * @return mixed The result of running the feature.
 	 */
-	public function call( $context = array() ) {
+	public function call( $rest_request ) {
 		/**
 		 * Filters the context before running a feature.
 		 *
@@ -441,6 +441,7 @@ class WP_Feature implements \JsonSerializable {
 		 * @param array      $context The context to run the feature with.
 		 * @param WP_Feature $feature The feature object.
 		 */
+		$context = $rest_request->get_param( 'context' );
 		$context = apply_filters( 'wp_feature_pre_run_context', $context, $this );
 		$context = apply_filters( $this->get_filter_id() . '_pre_run_context', $context, $this );
 
@@ -476,12 +477,10 @@ class WP_Feature implements \JsonSerializable {
 		 */
 		do_action( 'wp_feature_before_run', $context, $this );
 		do_action( $this->get_filter_id() . '_before_run', $context, $this );
-
 		$result = $context;
 		if ( $this->is_rest_alias() ) {
-			$request = new WP_REST_Request( $this->get_rest_method(), $this->get_rest_alias_route( $result ) );
-			$request->set_body_params( $result );
-			$response = rest_get_server()->dispatch( $request );
+			$rest_request->set_route( $this->get_rest_alias_route( $result ) );
+			$response = rest_get_server()->dispatch( $rest_request );
 			$result = $response->get_data();
 		} elseif ( is_callable( $this->callback ) ) {
 			$result = call_user_func( $this->callback, $context );

--- a/includes/rest-api/class-wp-rest-feature-controller.php
+++ b/includes/rest-api/class-wp-rest-feature-controller.php
@@ -494,7 +494,7 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 				array(
 					'methods'             => $feature->get_rest_method(),
 					'callback'            => function ( $request ) use ( $feature ) {
-						$result = $feature->call( $request->get_param( 'context' ) );
+						$result = $feature->call( $request );
 						return rest_ensure_response( $result );
 					},
 					'permission_callback' => array( $feature, 'get_permission_callback' ),


### PR DESCRIPTION
We had a regression and currently we can not execute any server registered tool with parameteres making it impossible to demonstrate the integration with MCP.

This PR fixes the issue, but we are setting all_fields_required to false that change is a must we can not say all fields are required but may have some side effects with the open ai assistant integration. cc: @emdashcodes. If we need to make all fiedls required for open ai that change should be done at the open ai agent level and not on the rest API.


## Testing instructions
<img width="1270" alt="Screenshot 2025-04-16 at 13 46 10" src="https://github.com/user-attachments/assets/8da0bfc1-f477-46bf-a1fb-ff24970a0d3d" />
