### PR TITLE
Make sure the BasicAgent passes "all_fields_required" for OpenAI strict mode

### DIFF
--- a/demo/wp-feature-api-demo/includes/Agent/BasicAgent.php
+++ b/demo/wp-feature-api-demo/includes/Agent/BasicAgent.php
@@ -101,6 +101,26 @@ class BasicAgent {
 	}
 
 	/**
+	 * Transform a schema using WP_Feature_Schema_Adapter with all_fields_required rule
+	 *
+	 * @param array $schema The schema to transform.
+	 * @param string $feature_id The ID of the feature for error logging.
+	 * @return array|null The transformed schema or null if transformation fails.
+	 */
+	private function transform_schema( array $schema, string $feature_id ): ?array {
+		// In strict mode, OpenAI requires all fields to be present in the object.
+		// @see https://platform.openai.com/docs/guides/function-calling?api-mode=chat#strict-mode
+		// @todo During the agent clean up, let's abstract this out for only OpenAI.
+		try {
+			$transformer = \WP_Feature_Schema_Adapter::make( null, $schema, array( 'all_fields_required' => true ) );
+			return $transformer->transform();
+		} catch ( \Exception $e ) {
+			error_log( 'Schema transformation failed for feature ' . $feature_id . ': ' . $e->getMessage() );
+			return null;
+		}
+	}
+
+	/**
 	 * Get tools from both server and client features
 	 *
 	 * @return array<array{type: string, function: array}>
@@ -246,7 +266,7 @@ class BasicAgent {
 			];
 
 			if ( is_array( $parameters ) && isset( $parameters['type'] ) && $parameters['type'] === 'object' && ! empty( $parameters['properties'] ) ) {
-				$function['parameters'] = $parameters;
+				$function['parameters'] = $this->transform_schema( $parameters, $feature->get_id() );
 			} else {
 				$function['parameters'] = [
 					'type'                 => 'object',
@@ -280,13 +300,7 @@ class BasicAgent {
 			$parameters      = $feature_data['input_schema'] ?? null;
 
 			if ( is_array( $parameters ) ) {
-				try {
-					$transformer = \WP_Feature_Schema_Adapter::make( null, $parameters );
-					$parameters  = $transformer->transform();
-				} catch ( \Exception $e ) {
-					error_log( 'Schema transformation failed for client feature ' . $feature_data['id'] . ': ' . $e->getMessage() );
-					$parameters = null;
-				}
+				$parameters = $this->transform_schema( $parameters, $feature_data['id'] );
 			}
 
 			$function = [

--- a/includes/class-wp-feature.php
+++ b/includes/class-wp-feature.php
@@ -430,10 +430,10 @@ class WP_Feature implements \JsonSerializable {
 	 * Calls the feature.
 	 *
 	 * @since 0.1.0
-	 * @param array $context The context to run the feature with.
+	 * @param array|WP_REST_Request $input The input to run the feature with. Can be an array of parameters or a WP_REST_Request object.
 	 * @return mixed The result of running the feature.
 	 */
-	public function call( $rest_request ) {
+	public function call( $input ) {
 		/**
 		 * Filters the context before running a feature.
 		 *
@@ -441,7 +441,12 @@ class WP_Feature implements \JsonSerializable {
 		 * @param array      $context The context to run the feature with.
 		 * @param WP_Feature $feature The feature object.
 		 */
-		$context = $rest_request->get_param( 'context' );
+		$context = array();
+		if ( is_array( $input ) ) {
+			$context = $input;
+		} elseif ( $input instanceof \WP_REST_Request ) {
+			$context = $input->get_param( 'context' );
+		}
 		$context = apply_filters( 'wp_feature_pre_run_context', $context, $this );
 		$context = apply_filters( $this->get_filter_id() . '_pre_run_context', $context, $this );
 
@@ -479,7 +484,13 @@ class WP_Feature implements \JsonSerializable {
 		do_action( $this->get_filter_id() . '_before_run', $context, $this );
 		$result = $context;
 		if ( $this->is_rest_alias() ) {
-			$rest_request->set_route( $this->get_rest_alias_route( $result ) );
+			if ( $input instanceof \WP_REST_Request ) {
+				$rest_request = $input;
+				$rest_request->set_route( $this->get_rest_alias_route( $result ) );
+			} else {
+				$rest_request = new WP_REST_Request( $this->get_rest_method(), $this->get_rest_alias_route( $result ) );
+				$rest_request->set_body_params( $result );
+			}
 			$response = rest_get_server()->dispatch( $rest_request );
 			$result = $response->get_data();
 		} elseif ( is_callable( $this->callback ) ) {


### PR DESCRIPTION
Depends on https://github.com/Automattic/wp-feature-api/pull/23

This PR sets `all_fields_required` to true specifically for the BasicAgent example. I'm currently working on rewriting the agent, so I'll probably abstract that out further -- but for now this lets both the MCP and Browser demos work properly.

It also fixes `call` which broke in the parent PR, as it started expecting a REST API object instead of an array of context that the LLM is currently passing.

## Testing Instructions

* Verify that you can execute tools from the MCP, like creating a new post
* Verify that you can execute server side tools from the demo agent, like requesting site info
* See that you can still `await wp.apiFetch( {path: 'wp/v2/features/resource-posts/run'}` in the browser and get a response
* Test that you can use client side tools within wp-admin, like navigating to the post editor or inserting a block