### PR TITLE
Add basic eligibility check for client features

### DIFF
--- a/demo/wp-feature-api-demo/src/hooks/use-message-handler.ts
+++ b/demo/wp-feature-api-demo/src/hooks/use-message-handler.ts
@@ -48,8 +48,14 @@ export const useMessageHandler = (
 				const registeredFeatures =
 					( await getRegisteredFeatures() ) || [];
 
+				// TODO: The agent is being re-worked so this isn't so directly coupled, but
+				// this allows us to filter out features that are not eligible to be used (i.e. post editor commands)
 				const clientFeatures = registeredFeatures
 					.filter( ( feature ) => feature?.location === 'client' )
+					.filter(
+						( feature ) =>
+							! feature.is_eligible || feature.is_eligible()
+					)
 					.map(
 						( {
 							id,

--- a/packages/client-features/src/blocks.ts
+++ b/packages/client-features/src/blocks.ts
@@ -12,6 +12,11 @@ import { dispatch } from '@wordpress/data';
 import type { Feature } from '@wp-feature-api/client';
 
 /**
+ * Internal dependencies
+ */
+import { isInPostEditor } from './utils/editor';
+
+/**
  * Client-side feature to insert a paragraph block.
  */
 export const insertParagraphBlock: Feature = {
@@ -23,6 +28,7 @@ export const insertParagraphBlock: Feature = {
 	type: 'tool',
 	location: 'client',
 	categories: [ 'core', 'editor', 'blocks' ],
+	is_eligible: isInPostEditor,
 	input_schema: {
 		type: 'object',
 		properties: {
@@ -77,6 +83,7 @@ export const insertHeadingBlock: Feature = {
 	type: 'tool',
 	location: 'client',
 	categories: [ 'core', 'editor', 'blocks' ],
+	is_eligible: isInPostEditor,
 	input_schema: {
 		type: 'object',
 		properties: {
@@ -142,6 +149,7 @@ export const insertQuoteBlock: Feature = {
 	type: 'tool',
 	location: 'client',
 	categories: [ 'core', 'editor', 'blocks' ],
+	is_eligible: isInPostEditor,
 	input_schema: {
 		type: 'object',
 		properties: {
@@ -209,6 +217,7 @@ export const insertListBlock: Feature = {
 	type: 'tool',
 	location: 'client',
 	categories: [ 'core', 'editor', 'blocks' ],
+	is_eligible: isInPostEditor,
 	input_schema: {
 		type: 'object',
 		properties: {

--- a/packages/client-features/src/editor.ts
+++ b/packages/client-features/src/editor.ts
@@ -11,6 +11,11 @@ import { select, dispatch } from '@wordpress/data';
 import type { Feature } from '@wp-feature-api/client';
 
 /**
+ * Internal dependencies
+ */
+import { isInPostEditor } from './utils/editor';
+
+/**
  * Client-side feature to set the post title.
  */
 export const setTitle: Feature = {
@@ -20,6 +25,7 @@ export const setTitle: Feature = {
 	type: 'tool',
 	location: 'client',
 	categories: [ 'client', 'editor' ],
+	is_eligible: isInPostEditor,
 	input_schema: {
 		type: 'object',
 		properties: {
@@ -64,6 +70,7 @@ export const savePost: Feature = {
 	type: 'tool',
 	location: 'client',
 	categories: [ 'client', 'editor' ],
+	is_eligible: isInPostEditor,
 	output_schema: {
 		type: 'object',
 		properties: {
@@ -97,6 +104,7 @@ export const getEditorContent: Feature = {
 	type: 'resource',
 	location: 'client',
 	categories: [ 'core', 'editor' ],
+	is_eligible: isInPostEditor,
 	output_schema: {
 		type: 'object',
 		properties: {

--- a/packages/client-features/src/utils/editor.ts
+++ b/packages/client-features/src/utils/editor.ts
@@ -1,0 +1,10 @@
+/**
+ * Helper function to check if we're in the WordPress post editor
+ */
+export const isInPostEditor = (): boolean => {
+	try {
+		return !! document.querySelector( '.block-editor' );
+	} catch ( error ) {
+		return false;
+	}
+};

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -16,6 +16,7 @@ export interface Feature {
 	input_schema?: Record< string, any >;
 	output_schema?: Record< string, any >;
 	location: 'server' | 'client';
+	is_eligible?: () => boolean;
 	callback?: (
 		args: any,
 		context: {
@@ -26,10 +27,4 @@ export interface Feature {
 
 export interface FeaturesState {
 	featuresById: Record< string, Feature >;
-}
-
-// Declare global variables provided by WordPress
-// Currently used for the navigate feature, but we may want to handle this a different way
-declare global {
-	const ajaxurl: string | undefined;
 }


### PR DESCRIPTION
This PR adds a basic eligibility check to blocks and editor features so that they don't try to execute on other wp-admin pages.

I am reworking the agent in `AIF-25/improve-feature-api-agent-demo`, so the current way of handling this (coupled in the agent) is considered temporary. See https://github.com/Automattic/wp-feature-api/pull/18#pullrequestreview-2764915988