### PR TITLE
Prepare for publishing the client package on NPM

### DIFF
--- a/packages/client/.npmignore
+++ b/packages/client/.npmignore
@@ -1,0 +1,22 @@
+# Source files
+src/
+
+# Development files
+node_modules/
+tsconfig.tsbuildinfo
+*.log
+*.tgz
+
+# Configuration files
+webpack.config.js
+tsconfig.json
+
+# Test files
+__tests__/
+*.test.ts
+*.test.js
+
+# Miscellaneous
+.DS_Store
+.vscode
+.idea

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,4 +1,4 @@
-# WordPress Feature API - Client SDK (@wp-feature-api/client)
+# WordPress Feature API - Client SDK (@automattic/wp-feature-api)
 
 This package provides the core client-side SDK for the WordPress Feature API. It allows client-side code running in the WordPress admin to register, discover, and execute features.
 
@@ -13,10 +13,29 @@ This package provides the core client-side SDK for the WordPress Feature API. It
 
 ## Installation
 
-This package is intended to be used within in `wp-feature-api` monorepo or consumed by third-party WordPress plugins once the package is published.
+```bash
+npm install @automattic/wp-feature-api
+```
 
-Within the monorepo, dependencies are managed via the root `package.json` and npm workspaces.
+## Usage
+
+```js
+import { registerFeature, executeFeature } from '@automattic/wp-feature-api';
+
+// Register a feature
+registerFeature({
+  id: 'my-feature',
+  title: 'My Feature',
+  callback: async (args) => {
+    // Feature implementation
+    return 'result';
+  }
+});
+
+// Execute a feature
+const result = await executeFeature('my-feature', { someArg: 'value' });
+```
 
 ## Build
 
-This package is built using `@wordpress/scripts`. Run `npm run build` from the monorepo root.
+This package is built using `@wordpress/scripts`. Run `npm run build` to build locally.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,13 +1,14 @@
 {
-  "name": "@wp-feature-api/client",
-  "version": "1.0.0",
+  "name": "@automattic/wp-feature-api",
+  "version": "0.1.0",
   "description": "Client-side SDK for WordPress Feature API",
   "main": "build/index.js",
   "types": "build-types/index.d.ts",
   "scripts": {
-    "build": "wp-scripts build && tsc --emitDeclarationOnly --outDir build",
+    "build": "wp-scripts build && tsc --emitDeclarationOnly --outDir build-types",
     "lint:js": "wp-scripts lint-js",
-    "clean": "rm -rf build build-types tsconfig.tsbuildinfo"
+    "clean": "rm -rf build build-types tsconfig.tsbuildinfo",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@wordpress/api-fetch": "^6.55.0",
@@ -24,5 +25,21 @@
   },
   "devDependencies": {
     "@wordpress/scripts": "^30.13.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/wp-feature-api.git",
+    "directory": "packages/client"
+  },
+  "author": "Automattic",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "wordpress",
+    "api",
+    "llm",
+    "ai"
+  ]
 }


### PR DESCRIPTION
This PR updates the package name from `@wp-feature-api/client` to `@automattic/wp-feature-api` and adds necessary configuration for publishing to NPM. Changes include:

- Renamed package from `@wp-feature-api/client` to `@automattic/wp-feature-api`
- Added `.npmignore` file to control package contents
- Updated README with installation and usage examples