### PR TITLE
Create simple hash for tool names as translation to hex can become too long

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -219,5 +219,6 @@ module.exports = {
 				},
 			},
 		],
+		'no-bitwise': 'off',
 	},
 };

--- a/demo/wp-feature-api-agent/src/agent/wp-feature-tool-provider.ts
+++ b/demo/wp-feature-api-agent/src/agent/wp-feature-tool-provider.ts
@@ -19,9 +19,9 @@ function stringToHex(str: string): string {
 	for (let i = 0; i < str.length; i++) {
 		const char = str.charCodeAt(i);
 		hash = ((hash << 5) + hash) + char;
-		hash = hash & hash; // Convert to 32bit integer
 	}
-	return Math.abs(hash).toString(16);
+	hash = hash >>> 0; // Convert to unsigned 32-bit integer
+	return hash.toString(16);
 }
 
 /**

--- a/demo/wp-feature-api-agent/src/agent/wp-feature-tool-provider.ts
+++ b/demo/wp-feature-api-agent/src/agent/wp-feature-tool-provider.ts
@@ -14,15 +14,14 @@ import type { Tool, ToolResult } from '../types/messages';
 import type { ToolProvider } from './tool-executor';
 
 // Helper function to convert a string to its hex representation
-function stringToHex( str: string ): string {
-	let hex = '';
-	for ( let i = 0; i < str.length; i++ ) {
-		const charCode = str.charCodeAt( i );
-		const hexValue = charCode.toString( 16 );
-		// Pad with leading zero if needed
-		hex += hexValue.padStart( 2, '0' );
+function stringToHex(str: string): string {
+	let hash = 0;
+	for (let i = 0; i < str.length; i++) {
+		const char = str.charCodeAt(i);
+		hash = ((hash << 5) - hash) + char;
+		hash = hash & hash; // Convert to 32bit integer
 	}
-	return hex;
+	return Math.abs(hash).toString(16);
 }
 
 /**

--- a/demo/wp-feature-api-agent/src/agent/wp-feature-tool-provider.ts
+++ b/demo/wp-feature-api-agent/src/agent/wp-feature-tool-provider.ts
@@ -14,14 +14,14 @@ import type { Tool, ToolResult } from '../types/messages';
 import type { ToolProvider } from './tool-executor';
 
 // Helper function to hash a string to a hex value using the djb2 hash algorithm
-function stringToHex(str: string): string {
+function stringToHex( str: string ): string {
 	let hash = 5381;
-	for (let i = 0; i < str.length; i++) {
-		const char = str.charCodeAt(i);
-		hash = ((hash << 5) + hash) + char;
+	for ( let i = 0; i < str.length; i++ ) {
+		const char = str.charCodeAt( i );
+		hash = ( hash << 5 ) + hash + char;
 	}
 	hash = hash >>> 0; // Convert to unsigned 32-bit integer
-	return hash.toString(16);
+	return hash.toString( 16 );
 }
 
 /**
@@ -53,6 +53,7 @@ export const createWpFeatureToolProvider = (): ToolProvider => {
 
 				return {
 					name: encodedToolName,
+					displayName: feature.id,
 					description: feature.description,
 					parameters: feature.input_schema || {},
 					execute: async (

--- a/demo/wp-feature-api-agent/src/agent/wp-feature-tool-provider.ts
+++ b/demo/wp-feature-api-agent/src/agent/wp-feature-tool-provider.ts
@@ -13,7 +13,7 @@ import {
 import type { Tool, ToolResult } from '../types/messages';
 import type { ToolProvider } from './tool-executor';
 
-// Helper function to convert a string to its hex representation
+// Helper function to hash a string to a hex value using the djb2 hash algorithm
 function stringToHex(str: string): string {
 	let hash = 5381;
 	for (let i = 0; i < str.length; i++) {

--- a/demo/wp-feature-api-agent/src/agent/wp-feature-tool-provider.ts
+++ b/demo/wp-feature-api-agent/src/agent/wp-feature-tool-provider.ts
@@ -15,10 +15,10 @@ import type { ToolProvider } from './tool-executor';
 
 // Helper function to convert a string to its hex representation
 function stringToHex(str: string): string {
-	let hash = 0;
+	let hash = 5381;
 	for (let i = 0; i < str.length; i++) {
 		const char = str.charCodeAt(i);
-		hash = ((hash << 5) - hash) + char;
+		hash = ((hash << 5) + hash) + char;
 		hash = hash & hash; // Convert to 32bit integer
 	}
 	return Math.abs(hash).toString(16);

--- a/demo/wp-feature-api-agent/src/components/ChatMessage.tsx
+++ b/demo/wp-feature-api-agent/src/components/ChatMessage.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Spinner } from '@wordpress/components';
+import { useContext } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -12,6 +13,7 @@ import Markdown from 'react-markdown';
  * Internal dependencies
  */
 import type { Message } from '../types/messages';
+import { ConversationContext } from '../context/ConversationProvider';
 
 interface MessageProps {
 	text: string;
@@ -25,27 +27,6 @@ export const UserMessage = ( { text }: MessageProps ) => (
 		<Markdown>{ text }</Markdown>
 	</div>
 );
-
-/**
- * Helper to decode hex tool names back to original feature IDs for display
- * @param hex
- */
-function hexToString( hex: string ): string {
-	if ( hex.length % 2 !== 0 ) {
-		return hex;
-	}
-
-	try {
-		return (
-			hex
-				.match( /.{1,2}/g )
-				?.map( ( byte ) => String.fromCharCode( parseInt( byte, 16 ) ) )
-				.join( '' ) || hex
-		);
-	} catch ( error ) {
-		return hex;
-	}
-}
 
 /**
  * Helper to attempt parsing JSON and formatting, falling back to raw string
@@ -70,17 +51,19 @@ function formatToolContent( content: string | null ): string {
  */
 export const AssistantMessage = ( { message }: { message: Message } ) => {
 	const { content, role, name, tool_calls: toolCalls } = message;
+	const context = useContext( ConversationContext );
+	const toolNameMap = context?.toolNameMap || {};
 
 	// Tool Message Rendering
 	if ( role === 'tool' ) {
-		const decodedName = name ? hexToString( name ) : 'unknown tool';
+		const displayName = name ? toolNameMap[ name ] || name : 'unknown tool';
 		const formattedContent = formatToolContent( content );
 		const hasError = content?.toLowerCase().includes( 'error:' );
 
 		return (
 			<div className="demo-chat-message demo-chat-message-tool">
 				<details open={ hasError }>
-					<summary>Tool Result: { decodedName }</summary>
+					<summary>Tool Result: { displayName }</summary>
 					<pre>
 						<code>{ formattedContent }</code>
 					</pre>
@@ -97,7 +80,8 @@ export const AssistantMessage = ( { message }: { message: Message } ) => {
 		toolCalls.length > 0
 	) {
 		const firstToolName = toolCalls[ 0 ].function?.name
-			? hexToString( toolCalls[ 0 ].function.name )
+			? toolNameMap[ toolCalls[ 0 ].function.name ] ||
+			  toolCalls[ 0 ].function.name
 			: 'unknown tool';
 		displayContent = `*Using tool: ${ firstToolName }...*`;
 	}

--- a/demo/wp-feature-api-agent/src/context/ConversationProvider.tsx
+++ b/demo/wp-feature-api-agent/src/context/ConversationProvider.tsx
@@ -14,6 +14,7 @@ import {
  * External dependencies
  */
 import { type ReactNode, type Dispatch, type SetStateAction } from 'react';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -29,6 +30,7 @@ export interface ConversationContextType {
 	sendMessage: ( query: string ) => Promise< void >;
 	isLoading: boolean;
 	clearConversation: () => void;
+	toolNameMap: Record< string, string >;
 }
 
 export const ConversationContext =
@@ -67,6 +69,9 @@ export const ConversationProvider = ( {
 	const [ toolExecutor, setToolExecutor ] = useState< ToolExecutor | null >(
 		null
 	);
+	const [ toolNameMap, setToolNameMap ] = useState<
+		Record< string, string >
+	>( {} );
 	const isInitializing = useRef( false );
 
 	useEffect( () => {
@@ -86,6 +91,15 @@ export const ConversationProvider = ( {
 			const provider = createWpFeatureToolProvider();
 			try {
 				await executor.addProvider( provider );
+
+				// Build hash-to-feature-name map, so we can display the feature name in the UI.
+				const tools = await Promise.resolve( provider.getTools() );
+				const nameMap: Record< string, string > = {};
+				for ( const tool of tools ) {
+					nameMap[ tool.name ] = tool.displayName;
+				}
+				setToolNameMap( nameMap );
+
 				setToolExecutor( executor );
 			} catch ( error ) {
 				// eslint-disable-next-line no-console
@@ -171,13 +185,24 @@ export const ConversationProvider = ( {
 			sendMessage,
 			isLoading,
 			clearConversation,
+			toolNameMap,
 		} ),
-		[ messages, setMessages, sendMessage, isLoading, clearConversation ]
+		[
+			messages,
+			setMessages,
+			sendMessage,
+			isLoading,
+			clearConversation,
+			toolNameMap,
+		]
 	);
+
+	// Wait until the tool name map is populated before rendering the chat UI.
+	const isReady = Object.keys( toolNameMap ).length > 0;
 
 	return (
 		<ConversationContext.Provider value={ contextValue }>
-			{ children }
+			{ ! isReady ? <div /> : children }
 		</ConversationContext.Provider>
 	);
 };

--- a/demo/wp-feature-api-agent/src/types/messages.ts
+++ b/demo/wp-feature-api-agent/src/types/messages.ts
@@ -25,6 +25,7 @@ export interface Message {
 
 export interface Tool {
 	name: string;
+	displayName: string;
 	description: string;
 	parameters: Record< string, any >;
 	execute: ( args: Record< string, unknown > ) => Promise< ToolResult >;


### PR DESCRIPTION
Translating tool's name into hexadecimal characters can quickly run over the limit of 64 characters from the API:

Error encountered:

```
"error": {
        "message": "Invalid 'tools[8].function.name': string too long. Expected a string with maximum length 64, but got a string with length 72 instead.",
        "type": "invalid_request_error",
        "param": "tools[8].function.name",
        "code": "string_above_max_length"
    }
```

This fix should solve it for now. It uses simple djb2 algo to hash the tool name to avoid collisions in case of a common prefix of tools (like `woocommerce_admin_*` etc).