### PR TITLE
Expose Feature API package as singleton with consistent script handle

### DIFF
--- a/demo/wp-feature-api-agent/wp-feature-api-agent.php
+++ b/demo/wp-feature-api-agent/wp-feature-api-agent.php
@@ -66,7 +66,7 @@ function wp_feature_api_agent_enqueue_assets() {
 	wp_enqueue_script(
 		'wp-feature-api-agent-script',
 		WP_AI_API_PROXY_URL . 'build/index.js',
-		$script_asset['dependencies'],
+		array_merge( $script_asset['dependencies'], array( 'wp-features' ) ),
 		$script_asset['version'],
 		true // Load in footer.
 	);

--- a/docs/7.client-side-features.md
+++ b/docs/7.client-side-features.md
@@ -4,7 +4,19 @@ While the core PHP classes primarily manage server-side features (executed withi
 
 **The `@wp-feature-api/client` Package**
 
-All client-side interactions (registration, execution, discovery) rely on the `@wp-feature-api/client` package. This package provides the necessary functions and manages a client-side registry mirroring the server-side one. Ensure this package is available and properly initialized in your client-side environment.
+All client-side interactions (registration, execution, discovery) rely on the `@automattic/wp-feature-api` package. This package provides the necessary functions and manages a client-side registry mirroring the server-side one.
+
+**Important Setup Prerequisites:**
+
+The `@automattic/wp-feature-api` client SDK is designed to work as a singleton, provided by the main "WordPress Feature API" plugin. To use it in your own plugin's JavaScript:
+
+1. **Main Plugin Active:** Ensure the "WordPress Feature API" plugin is installed and active on your site.
+2. **Script Dependency:** When enqueuing your plugin's JavaScript file, you must declare `'wp-features'` (the script handle for the client SDK provided by the main plugin) as a dependency.
+3. **Webpack Externals:** If you are using webpack (or a similar bundler), you must configure `@automattic/wp-feature-api` as an external module. This tells your bundler not to include the SDK code in your bundle and to instead use the version provided globally by the main plugin (via `window.wp.features`).
+
+For detailed setup instructions, including `wp_enqueue_script` and webpack configuration examples, please refer to the [README in the client package](../packages/client/README.md).
+
+Ensure this package is available and properly initialized in your client-side environment by following these setup steps.
 
 ## Registration
 
@@ -12,8 +24,7 @@ All client-side interactions (registration, execution, discovery) rely on the `@
 * **Example:** The `@wp-feature-api/client-features` package uses this approach to register core editor features like inserting blocks or saving posts.
 
  ```javascript
- // Example (Simplified from packages/client-features)
- import { registerFeature } from '@wp-feature-api/client';
+ import { registerFeature } from '@automattic/wp-feature-api';
 
  const insertParagraph = {
   id: 'core/insert-paragraph',

--- a/docs/7.client-side-features.md
+++ b/docs/7.client-side-features.md
@@ -2,17 +2,15 @@
 
 While the core PHP classes primarily manage server-side features (executed within the WordPress backend), the Feature API also supports client-side features implemented in JavaScript and executed in the user's browser.
 
-**The `@wp-feature-api/client` Package**
+**The `@automattic/wp-feature-api` Package**
 
 All client-side interactions (registration, execution, discovery) rely on the `@automattic/wp-feature-api` package. This package provides the necessary functions and manages a client-side registry mirroring the server-side one.
 
-**Important Setup Prerequisites:**
-
-The `@automattic/wp-feature-api` client SDK is designed to work as a singleton, provided by the main "WordPress Feature API" plugin. To use it in your own plugin's JavaScript:
+The `@automattic/wp-feature-api` package is designed to work as a singleton, provided by the main "WordPress Feature API" plugin. To use it in your own plugin's JavaScript:
 
 1. **Main Plugin Active:** Ensure the "WordPress Feature API" plugin is installed and active on your site.
 2. **Script Dependency:** When enqueuing your plugin's JavaScript file, you must declare `'wp-features'` (the script handle for the client SDK provided by the main plugin) as a dependency.
-3. **Webpack Externals:** If you are using webpack (or a similar bundler), you must configure `@automattic/wp-feature-api` as an external module. This tells your bundler not to include the SDK code in your bundle and to instead use the version provided globally by the main plugin (via `window.wp.features`).
+3. **Webpack Externals:** If you are using webpack (or a similar bundler), you should configure `@automattic/wp-feature-api` as an external module. This tells your bundler not to include the SDK code in your bundle and to instead use the version provided globally by the main plugin (via `window.wp.features`).
 
 For detailed setup instructions, including `wp_enqueue_script` and webpack configuration examples, please refer to the [README in the client package](../packages/client/README.md).
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -32,17 +32,17 @@ $asset_file = include( plugin_dir_path( __FILE__ ) . 'build/index.asset.php' ); 
 wp_enqueue_script(
     'your-plugin-script-handle',
     plugin_dir_url( __FILE__ ) . 'build/index.js',
-    array_merge( $asset_file['dependencies'], array( 'wp-features' ) ), // Add 'wp-features'
+    array_merge( $asset_file['dependencies'], array( 'wp-features' ) ), // Add 'wp-features' to the dependencies
     $asset_file['version'],
     true
 );
 ```
 
-If you are not using `@wordpress/scripts` to generate an `index.asset.php` file, ensure you manually add relevant dependencies like `wp-data`, `wp-core-data`, `wp-api-fetch`, `wp-plugins`, in addition to `wp-features`.
+If you are not using `@wordpress/scripts` to generate an `index.asset.php` file, you may need to add relevant dependencies like `wp-data`, `wp-core-data`, `wp-api-fetch`, `wp-plugins`, in addition to `wp-features`.
 
 ## Webpack Configuration
 
-To ensure that your plugin uses the single instance of the client SDK provided by the main `wp-feature-api` plugin (and to avoid bundling the SDK code into your plugin), you need to configure `@automattic/wp-feature-api` as an external in your webpack configuration.
+To ensure that your plugin uses the client SDK provided by the main `wp-feature-api` plugin (and to avoid bundling the SDK code into your plugin), you need to configure `@automattic/wp-feature-api` as an external in your webpack configuration.
 
 This tells webpack to expect `@automattic/wp-feature-api` to be available globally as `window.wp.features` at runtime.
 
@@ -54,12 +54,7 @@ module.exports = {
     '@automattic/wp-feature-api': ['wp', 'features'],
     // It's good practice to also externalize other @wordpress packages
     '@wordpress/data': 'wp.data',
-    '@wordpress/element': 'wp.element',
-    '@wordpress/api-fetch': 'wp.apiFetch',
-    '@wordpress/i18n': 'wp.i18n',
-    '@wordpress/plugins': 'wp.plugins',
-    '@wordpress/core-data': 'wp.coreData',
-    // Add any other @wordpress packages you use directly
+    // Add any other @wordpress packages you use directly...
   }
 };
 ```

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -17,24 +17,51 @@ This package provides the core client-side SDK for the WordPress Feature API. It
 npm install @automattic/wp-feature-api
 ```
 
-## WordPress Dependencies
+## WordPress Script Dependencies & Enqueueing
 
-This package relies on WordPress core packages that may need to be properly loaded before using this package in WordPress or wp-admin.
+This package is designed to work as a singleton, provided by the main "WordPress Feature API" plugin. Ensure the main `wp-feature-api` plugin is installed and active on your WordPress site before using this package.
+
+When using `@automattic/wp-feature-api` in your WordPress plugin, you must declare the correct dependencies in your `wp_enqueue_script` call. The main `wp-feature-api` plugin provides the actual client script.
+
+1. **Ensure the main "WordPress Feature API" plugin is active.**
+2. Add `'wp-features'` to your script's dependency array. This is the handle for the client SDK provided by the main plugin.
 
 ```php
-// When enqueueing your script that uses @automattic/wp-feature-api, include these dependencies:
+$asset_file = include( plugin_dir_path( __FILE__ ) . 'build/index.asset.php' ); // If using @wordpress/scripts
+
 wp_enqueue_script(
-    'your-script-handle',
-    'path/to/your/script.js',
-    [
-		'wp-data',
-		'wp-core-data',
-		'wp-api-fetch',
-		'wp-plugins'
-    ],
-    '1.0.0',
+    'your-plugin-script-handle',
+    plugin_dir_url( __FILE__ ) . 'build/index.js',
+    array_merge( $asset_file['dependencies'], array( 'wp-features' ) ), // Add 'wp-features'
+    $asset_file['version'],
     true
 );
+```
+
+If you are not using `@wordpress/scripts` to generate an `index.asset.php` file, ensure you manually add relevant dependencies like `wp-data`, `wp-core-data`, `wp-api-fetch`, `wp-plugins`, in addition to `wp-features`.
+
+## Webpack Configuration
+
+To ensure that your plugin uses the single instance of the client SDK provided by the main `wp-feature-api` plugin (and to avoid bundling the SDK code into your plugin), you need to configure `@automattic/wp-feature-api` as an external in your webpack configuration.
+
+This tells webpack to expect `@automattic/wp-feature-api` to be available globally as `window.wp.features` at runtime.
+
+```javascript
+// In your plugin's webpack.config.js
+module.exports = {
+  // ... other webpack config
+  externals: {
+    '@automattic/wp-feature-api': ['wp', 'features'],
+    // It's good practice to also externalize other @wordpress packages
+    '@wordpress/data': 'wp.data',
+    '@wordpress/element': 'wp.element',
+    '@wordpress/api-fetch': 'wp.apiFetch',
+    '@wordpress/i18n': 'wp.i18n',
+    '@wordpress/plugins': 'wp.plugins',
+    '@wordpress/core-data': 'wp.coreData',
+    // Add any other @wordpress packages you use directly
+  }
+};
 ```
 
 ## Usage

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,32 @@
-export { store } from './store';
+/**
+ * Internal dependencies
+ */
+import { store } from './store';
+import {
+	registerFeature,
+	unregisterFeature,
+	executeFeature,
+	getRegisteredFeature,
+	getRegisteredFeatures,
+} from './api';
+
+const publicApi = {
+	store,
+	registerFeature,
+	unregisterFeature,
+	executeFeature,
+	getRegisteredFeature,
+	getRegisteredFeatures,
+};
+
+if ( typeof window !== 'undefined' ) {
+	// @ts-ignore
+	window.wp = window.wp || {};
+	// @ts-ignore
+	window.wp.features = publicApi;
+}
+
+export { store };
 export * from './types';
 export {
 	registerFeature,
@@ -6,5 +34,6 @@ export {
 	executeFeature,
 	getRegisteredFeature,
 	getRegisteredFeatures,
-} from './api';
+};
 export * from './command-integration';
+export { publicApi as wpFeatures };

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import '@wp-feature-api/client';
 import { registerCoreFeatures } from '@wp-feature-api/client-features';
 
 registerCoreFeatures();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,10 @@ const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extrac
 const path = require( 'path' );
 module.exports = {
 	...defaultConfig,
+	externals: {
+		...defaultConfig.externals,
+		'@automattic/wp-feature-api': 'wp.features',
+	},
 	plugins: [
 		...defaultConfig.plugins.filter(
 			( plugin ) =>
@@ -23,10 +27,6 @@ module.exports = {
 		...defaultConfig.resolve,
 		alias: {
 			...defaultConfig.resolve?.alias,
-			'@wp-feature-api/client': path.resolve(
-				__dirname,
-				'packages/client/src'
-			),
 			'@wp-feature-api/client-features': path.resolve(
 				__dirname,
 				'packages/client-features/src'

--- a/wp-feature-api.php
+++ b/wp-feature-api.php
@@ -63,7 +63,7 @@ function wp_feature_api_enqueue_admin_scripts() {
 		return;
 	}
 	$assets = require WP_FEATURE_API_PLUGIN_DIR . 'build/index.asset.php';
-	wp_enqueue_script( 'wp_feature_api_script', WP_FEATURE_API_PLUGIN_URL . 'build/index.js', $assets['dependencies'], $assets['version'], true );
+	wp_enqueue_script( 'wp-features', WP_FEATURE_API_PLUGIN_URL . 'build/index.js', $assets['dependencies'], $assets['version'], true );
 }
 
 /**


### PR DESCRIPTION
Closes `AI-156/ensure-packagescript-is-used-as-a-singleton-in-plugins`

This PR updates the Feature API client package to function as a singleton within WordPress. This is to help make sure that only the main plugin script/instance for the WP Feature API is loaded, much how other scripts like `wp-data` is handled

- Exposes client SDK through `window.wp.features` global (also part of the RFC)
- Sets script handle to 'wp-features'
- Updates documentation with setup instructions

## Testing Instructions
1. Activate the main WordPress Feature API plugin
2. Pull down https://github.com/emdashcodes/wp-feature-api-test, run `npm install` and `npm build` and activate the additional Test plugin
3. Verify that the test plugin returns some output in the console, including registered features
4. Verify that `await window.wp.features.getRegisteredFeatures()` returns an array of registered features 