### PR TITLE
Update version logic to prioritize direct installations (for developing)

### DIFF
--- a/docs/8.advanced-topics.md
+++ b/docs/8.advanced-topics.md
@@ -11,9 +11,10 @@ The WordPress Feature API includes a built-in version management system that ena
   1. Each plugin includes its copy of the Feature API via `require_once`
   2. When loaded, each version registers itself using `wp_feature_api_register_version()`
   3. The version resolver (`wp_feature_api_version_resolver()`) identifies the highest version
-  4. Only that version's code is fully initialized
-  5. The `wp_feature_api_init` action is fired when initialization is complete
-  6. All plugins register their features using this hook
+  4. The system will priortize a direct installation of the Feature API over a bundled version if they both have the same version string
+  5. Only that version's code is fully initialized
+  6. The `wp_feature_api_init` action is fired when initialization is complete
+  7. All plugins register their features using this hook
 
 ## Repositories (`WP_Feature_Repository_Interface`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-feature-api",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "A system for exposing WordPress functionality in a standardized, discoverable way for both server and client-side use",
 	"main": "src/index.js",
 	"private": true,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/wp-feature-api",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Client-side SDK for WordPress Feature API",
   "main": "build/index.js",
   "types": "build-types/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { registerCoreFeatures } from '@wp-feature-api/client-features';
+import { coreFeatures } from '../packages/client-features/src';
+import { registerFeature } from '../packages/client/src/api';
 
-registerCoreFeatures();
+coreFeatures.filter( ( feature ) => !! feature ).forEach( registerFeature );

--- a/wp-feature-api.php
+++ b/wp-feature-api.php
@@ -3,7 +3,7 @@
  * Plugin Name: WordPress Feature API
  * Plugin URI: https://github.com/Automattic/wp-feature-api
  * Description: A system for exposing server and client-side functionality in WordPress for use in LLMs and agentic systems.
- * Version: 0.1.3
+ * Version: 0.1.4
  * Author: Automattic AI
  * Author URI: https://automattic.ai/
  * Text Domain: wp-feature-api
@@ -18,16 +18,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$wp_feature_api_version = '0.1.3';
+$wp_feature_api_version = '0.1.4';
 $wp_feature_api_plugin_dir = plugin_dir_path( __FILE__ );
 $wp_feature_api_plugin_url = plugin_dir_url( __FILE__ );
 
 /**
  * Define this constant as true in wp-config.php to load the demo plugin.
+ * The plugin is bundled with the development version, or released separately on GitHub.
+ * The Composer version does not include the demo plugin.
  * Example: define( 'WP_FEATURE_API_LOAD_DEMO', true );
  */
 if ( ! defined( 'WP_FEATURE_API_LOAD_DEMO' ) ) {
-	define( 'WP_FEATURE_API_LOAD_DEMO', true );
+	define( 'WP_FEATURE_API_LOAD_DEMO', false );
 }
 
 // Version registry.
@@ -48,7 +50,14 @@ if ( ! function_exists( 'wp_feature_api_register_version' ) ) {
 	 */
 	function wp_feature_api_register_version( $version, $file ) {
 		global $wp_feature_api_versions;
-		$wp_feature_api_versions[ $version ] = $file;
+		// Generate a unique key using version + path hash to prevent overwriting
+		// installations of the same version in different directories. This is so we can
+		// provide a preference for the plugin/developer version over a vendor version.
+		$unique_key = $version . '|' . md5($file);
+		$wp_feature_api_versions[$unique_key] = array(
+			'version' => $version,
+			'file' => $file,
+		);
 	}
 }
 
@@ -86,24 +95,72 @@ if ( ! function_exists( 'wp_feature_api_version_resolver' ) ) {
 			return;
 		}
 
-		// Find highest version.
-		$versions = array_keys( $wp_feature_api_versions );
-		$highest_version = $versions[0];
-		foreach ( $versions as $version ) {
-			if ( version_compare( $version, $highest_version, '>' ) ) {
-				$highest_version = $version;
+		$plugin_dir_version = null;
+		$plugin_dir_file = null;
+		$vendor_highest_version = null;
+		$vendor_highest_file = null;
+
+		// Always prioritize direct plugin installation over vendor installation
+		// Separate versions by location and find highest for each
+		foreach ( $wp_feature_api_versions as $unique_key => $data ) {
+			$version = $data['version'];
+			$file_path = $data['file'];
+
+			if ( false === strpos( $file_path, '/vendor/' ) ) {
+				// Direct plugin installation
+				if ( null === $plugin_dir_version || version_compare( $version, $plugin_dir_version, '>' ) ) {
+					$plugin_dir_version = $version;
+					$plugin_dir_file = $file_path;
+				}
+			} else {
+				// Vendor installation
+				if ( null === $vendor_highest_version || version_compare( $version, $vendor_highest_version, '>' ) ) {
+					$vendor_highest_version = $version;
+					$vendor_highest_file = $file_path;
+				}
 			}
+		}
+
+		// Choose the overall highest version, with a preference for plugin directory at equal versions
+		if ( null !== $plugin_dir_version && null !== $vendor_highest_version ) {
+			$version_compare = version_compare( $plugin_dir_version, $vendor_highest_version );
+
+			if ( $version_compare > 0 ) {
+				$highest_version = $plugin_dir_version;
+				$file_to_load = $plugin_dir_file;
+			} elseif ( $version_compare < 0 ) {
+				$highest_version = $vendor_highest_version;
+				$file_to_load = $vendor_highest_file;
+			} else {
+				// Versions are equal, prioritize the plugin directory version
+				$highest_version = $plugin_dir_version;
+				$file_to_load = $plugin_dir_file;
+			}
+		} elseif ( null !== $plugin_dir_version ) {
+			$highest_version = $plugin_dir_version;
+			$file_to_load = $plugin_dir_file;
+		} else {
+			$highest_version = $vendor_highest_version;
+			$file_to_load = $vendor_highest_file;
 		}
 
 		define( 'WP_FEATURE_API_VERSION', $highest_version );
 		define( 'WP_FEATURE_API_ACTIVE_VERSION', $highest_version );
 
 		// Load the highest version.
-		$file_to_load = $wp_feature_api_versions[ $highest_version ];
 		$dir = dirname( $file_to_load );
 
 		define( 'WP_FEATURE_API_PLUGIN_DIR', trailingslashit( $dir ) );
-		define( 'WP_FEATURE_API_PLUGIN_URL', plugins_url( '/', $file_to_load ) );
+
+		// When loaded via Composer, the file might be in the vendor directory, not plugins
+		if ( false !== strpos( $file_to_load, '/vendor/' ) ) {
+			// We're in a Composer installation, get the URL directly from WP_CONTENT_URL
+			$vendor_rel_path = str_replace( WP_CONTENT_DIR, '', dirname( $file_to_load ) );
+			define( 'WP_FEATURE_API_PLUGIN_URL', trailingslashit( content_url( $vendor_rel_path ) ) );
+		} else {
+			// Standard plugin installation
+			define( 'WP_FEATURE_API_PLUGIN_URL', plugins_url( '/', $file_to_load ) );
+		}
 
 		// Now load the API from the highest version.
 		require_once $dir . '/includes/load.php';


### PR DESCRIPTION
This updates the version handling so that if you install the wp-feature-api directly (either via the plugin zip or GitHub), it will be prioritized by a vendor version of the same release. 

This also simplifies the main JavaScript entry point as there was some issues with the bundle in the composer version.