### PR TITLE
Fix the example client feature definition in the readme

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -67,7 +67,10 @@ import { registerFeature, executeFeature } from '@automattic/wp-feature-api';
 // Register a feature
 registerFeature({
   id: 'my-feature',
-  title: 'My Feature',
+  name: 'My Feature',
+  description: 'My Feature Description',
+  type: 'tool',
+  location: 'client',
   callback: async (args) => {
     // Feature implementation
     return 'result';


### PR DESCRIPTION
Currently the client readme example doesn't work as it defaults to trying to call the REST endpoint. Setting the location to `client` fixes it - but the example also specified `title` instead of `name`.

## Testing
 - Check that my changes are correct  - worked for me with these changes applied to  a test example locally - failed with a REST 404 without location set to client.