### PR TITLE
Add proper oneOf handling

### DIFF
--- a/includes/class-wp-feature-schema-adapter.php
+++ b/includes/class-wp-feature-schema-adapter.php
@@ -317,19 +317,23 @@ class WP_Feature_Schema_Adapter {
 				continue;
 			}
 
-			/**
-			 * Handle oneOf multiple types
-			 *
-			 * @todo: This is a cheap shortcut to shut-off 'oneOf' for now.
-			 */
-			if (
-				isset( $value['oneOf'] ) &&
-				is_array( $value['oneOf'] )
-			) {
-				$value['type']  = 'array';
-				$value['items'] = $value['oneOf'][0];
-				unset( $value['oneOf'] );
-			}
+                       /**
+                        * Handle oneOf multiple types.
+                        *
+                        * Recursively process each schema option rather than
+                        * forcing the first option into an array. This allows
+                        * valid union types to be preserved.
+                        */
+                       if (
+                               isset( $value['oneOf'] ) &&
+                               is_array( $value['oneOf'] )
+                       ) {
+                               foreach ( $value['oneOf'] as $index => $option ) {
+                                       if ( is_array( $option ) ) {
+                                               $value['oneOf'][ $index ] = $this->rule_strict_object_encoding( $rule_name, $option );
+                                       }
+                               }
+                       }
 
 			/**
 			 * Handle enum objects

--- a/phpunit/tests/schema-oneof-test.php
+++ b/phpunit/tests/schema-oneof-test.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * OneOf Schema Test.
+ *
+ * @package WordPress\Features_API
+ */
+class WP_Schema_OneOf_Test extends WP_UnitTestCase {
+        public function set_up() {
+                parent::set_up();
+                wp_register_feature( array(
+                        'id'          => 'oneof-test',
+                        'name'        => 'OneOf Test',
+                        'description' => 'Test feature with oneOf schema',
+                        'type'        => 'tool',
+                        'callback'    => function( $context ) { return $context; },
+                        'input_schema' => array(
+                                'type'       => 'object',
+                                'properties' => array(
+                                        'value' => array(
+                                                'oneOf'   => array(
+                                                        array( 'type' => 'string' ),
+                                                        array( 'type' => 'integer' ),
+                                                ),
+                                                'required' => true,
+                                        ),
+                                ),
+                        ),
+                        'output_schema' => array(
+                                'type'       => 'object',
+                                'properties' => array(
+                                        'value' => array(
+                                                'oneOf' => array(
+                                                        array( 'type' => 'string' ),
+                                                        array( 'type' => 'integer' ),
+                                                ),
+                                        ),
+                                ),
+                        ),
+                ) );
+        }
+
+        public function tear_down() {
+                wp_unregister_feature( 'oneof-test' );
+                parent::tear_down();
+        }
+
+        public function test_oneof_accepts_string_or_integer() {
+                $feature = wp_find_feature( 'oneof-test' );
+                $request = new WP_REST_Request( $feature->get_rest_method(), '/' );
+                $request->set_param( 'value', 'hello' );
+                $result = $feature->call( $request );
+                $this->assertIsArray( $result );
+                $this->assertSame( 'hello', $result['value'] );
+
+                $request = new WP_REST_Request( $feature->get_rest_method(), '/' );
+                $request->set_param( 'value', 123 );
+                $result = $feature->call( $request );
+                $this->assertIsArray( $result );
+                $this->assertSame( 123, $result['value'] );
+        }
+
+        public function test_oneof_rejects_invalid_type() {
+                $feature = wp_find_feature( 'oneof-test' );
+                $request = new WP_REST_Request( $feature->get_rest_method(), '/' );
+                $request->set_param( 'value', array( 'invalid' ) );
+                $result = $feature->call( $request );
+                $this->assertInstanceOf( WP_Error::class, $result );
+        }
+}


### PR DESCRIPTION
## Summary
- fix `oneOf` support in the schema adapter
- add PHPUnit test covering `oneOf` validation

## Testing
- `composer lint` *(fails: composer not found)*