### PR TITLE
Add static feature loader

### DIFF
--- a/features.json
+++ b/features.json
@@ -1,0 +1,18 @@
+[
+    {
+        "id": "demo/site-info",
+        "name": "Site Information",
+        "description": "Get basic information about the WordPress site.",
+        "type": "resource",
+        "categories": ["demo", "site", "information"],
+        "server_callback": "includes/feature-callbacks/site-info.php"
+    },
+    {
+        "id": "demo/client-alert",
+        "name": "Client Alert",
+        "description": "Show an alert in the browser.",
+        "type": "tool",
+        "categories": ["demo", "client"],
+        "client_callback": "includes/feature-callbacks/client-alert.js"
+    }
+]

--- a/includes/feature-callbacks/client-alert.js
+++ b/includes/feature-callbacks/client-alert.js
@@ -1,0 +1,3 @@
+export default function() {
+    window.alert('Feature API client alert');
+}

--- a/includes/feature-callbacks/site-info.php
+++ b/includes/feature-callbacks/site-info.php
@@ -1,0 +1,15 @@
+<?php
+return function( $input ) {
+    return array(
+        'name'        => get_bloginfo( 'name' ),
+        'description' => get_bloginfo( 'description' ),
+        'url'         => home_url(),
+        'version'     => get_bloginfo( 'version' ),
+        'language'    => get_bloginfo( 'language' ),
+        'timezone'    => wp_timezone_string(),
+        'date_format' => get_option( 'date_format' ),
+        'time_format' => get_option( 'time_format' ),
+        'active_plugins' => get_option( 'active_plugins' ),
+        'active_theme' => get_option( 'stylesheet' ),
+    );
+};

--- a/includes/load.php
+++ b/includes/load.php
@@ -21,3 +21,33 @@ require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/rest-api/class-wp-rest-featur
 require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/default-wp-features.php';
 // Include initialization class.
 require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-api-init.php';
+
+// Load additional features defined in features.json.
+$features_file = WP_FEATURE_API_PLUGIN_DIR . 'features.json';
+if ( file_exists( $features_file ) ) {
+    $features_data = file_get_contents( $features_file );
+    if ( false !== $features_data ) {
+        $features = json_decode( $features_data, true );
+        if ( is_array( $features ) ) {
+            foreach ( $features as $feature ) {
+                if ( isset( $feature['server_callback'] ) ) {
+                    $callback_file = WP_FEATURE_API_PLUGIN_DIR . ltrim( $feature['server_callback'], '/' );
+                    if ( file_exists( $callback_file ) ) {
+                        $feature['callback'] = require $callback_file;
+                    }
+                    unset( $feature['server_callback'] );
+                }
+
+                if ( isset( $feature['client_callback'] ) ) {
+                    if ( ! isset( $feature['meta'] ) || ! is_array( $feature['meta'] ) ) {
+                        $feature['meta'] = array();
+                    }
+                    $feature['meta']['client_callback'] = $feature['client_callback'];
+                    unset( $feature['client_callback'] );
+                }
+
+                wp_register_feature( $feature );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `features.json` config at the project root
- dynamically load features from JSON in `includes/load.php`
- support optional `server_callback` and `client_callback`
- add example callback implementations

## Testing
- `npm run lint:js` *(fails: `wp-scripts` not found)*
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*