### PR TITLE
Support lazy client feature callbacks

### DIFF
--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -67,19 +67,29 @@ export async function executeFeature(
 		throw new Error( `Feature not found: ${ featureId }` );
 	}
 
-	try {
-		if ( feature.location === 'client' ) {
-			const callback =
-				select( store ).getRegisteredFeatureCallback( featureId );
+        try {
+                if ( feature.location === 'client' ) {
+                        let callback =
+                                select( store ).getRegisteredFeatureCallback( featureId );
 
-			if ( typeof callback !== 'function' ) {
-				throw new Error(
-					`No callback registered for client feature: ${ featureId }`
-				);
-			}
+                        if ( typeof callback !== 'function' && feature.client_callback ) {
+                                const module = await import(
+                                        /* webpackIgnore: true */ feature.client_callback
+                                );
+                                callback = module.default || module;
+                                if ( typeof callback === 'function' ) {
+                                        dispatch( store ).registerFeatureCallback( featureId, callback );
+                                }
+                        }
 
-			return await callback( args );
-		}
+                        if ( typeof callback !== 'function' ) {
+                                throw new Error(
+                                        `No callback registered for client feature: ${ featureId }`
+                                );
+                        }
+
+                        return await callback( args );
+                }
 
 		// Server-side features
 		const method = feature.type === 'tool' ? 'POST' : 'GET';

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -15,9 +15,14 @@ export interface Feature {
 	categories: string[];
 	input_schema?: Record< string, any >;
 	output_schema?: Record< string, any >;
-	location: 'server' | 'client';
-	icon?: any;
-	is_eligible?: () => boolean;
+        location: 'server' | 'client';
+        icon?: any;
+       /**
+        * Path to the module exporting the callback for this client feature.
+        * Used when the callback is lazily loaded from a features.json file.
+        */
+       client_callback?: string;
+        is_eligible?: () => boolean;
 	callback?: (
 		args: any,
 		context: {

--- a/src/features/features.json
+++ b/src/features/features.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "tool-navigate",
+    "name": "Navigate Browser",
+    "description": "Navigates the browser to a specified URL in WordPress.",
+    "type": "tool",
+    "location": "client",
+    "categories": ["core", "navigation"],
+    "input_schema": {
+      "type": "object",
+      "properties": {"url": {"type": "string", "ui_hint": "url", "pattern": "^/"}},
+      "required": ["url"]
+    },
+    "client_callback": "../packages/client-features/src/navigation.ts"
+  }
+]

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { coreFeatures } from '../packages/client-features/src';
+import featureData from './features/features.json';
 import { registerFeature } from '../packages/client/src/api';
 
-coreFeatures.filter( ( feature ) => !! feature ).forEach( registerFeature );
+featureData.filter( ( feature ) => !! feature ).forEach( registerFeature );


### PR DESCRIPTION
## Summary
- add `client_callback` metadata to Feature type
- allow lazy loading callback modules in `executeFeature`
- register features from new `features.json`
- include example metadata for `tool-navigate`

## Testing
- `no tests available`
