### PR TITLE
Implement feature group support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Filtering can be done by:
 - Querying feature properties
 - Keyword search across name, description, and ID.
 - Categories
+- Feature groups
 - `is_eligible` boolean callback
 - Context matching for when we already have some context and want Features that can be fulfilled using that context.
 

--- a/demo/wp-feature-api-agent/README.md
+++ b/demo/wp-feature-api-agent/README.md
@@ -12,3 +12,8 @@ This demo plugin showcases how to use the WordPress Feature API, including regis
 4. Navigate to "Settings" -> "WP Feature Agent Demo" in the WordPress admin to configure your OpenAI API key.
 5. Refresh and see the AI Agent chat interface.
 6. Ask the AI Agent questions about your WordPress site and features. It has access to both server-side and client-side features.
+7. Features in this demo are grouped under the `demo` group. You can query only these features using `wp_get_features( array( 'group' => 'demo' ) )` or via the client library:
+
+   ```javascript
+   const demoFeatures = await getRegisteredFeatures( { group: 'demo' } );
+   ```

--- a/demo/wp-feature-api-agent/includes/class-wp-feature-register.php
+++ b/demo/wp-feature-api-agent/includes/class-wp-feature-register.php
@@ -28,19 +28,29 @@ class WP_Feature_Register {
 	 * @since 0.1.0
 	 * @return void
 	 */
-	public function register_features() {
-		/** Global Features */
-		wp_register_feature(
-			array(
-				'id'          => 'demo/site-info',
-				'name'        => __( 'Site Information', 'wp-feature-api-agent' ),
-				'description' => __( 'Get basic information about the WordPress site. This includes the name, description, URL, version, language, timezone, date format, time format, active plugins, and active theme.', 'wp-feature-api-agent' ),
-				'type'        => WP_Feature::TYPE_RESOURCE,
-				'categories'  => array( 'demo', 'site', 'information' ),
-				'callback'    => array( $this, 'site_info_callback' ),
-			)
-		);
-	}
+        public function register_features() {
+                /** Global Features */
+                wp_register_feature(
+                        array(
+                                'id'          => 'demo/site-info',
+                                'name'        => __( 'Site Information', 'wp-feature-api-agent' ),
+                                'description' => __( 'Get basic information about the WordPress site. This includes the name, description, URL, version, language, timezone, date format, time format, active plugins, and active theme.', 'wp-feature-api-agent' ),
+                                'type'        => WP_Feature::TYPE_RESOURCE,
+                                'categories'  => array( 'demo', 'site', 'information' ),
+                                'callback'    => array( $this, 'site_info_callback' ),
+                        )
+                );
+
+               // Register a feature group for demo features.
+               wp_register_feature_group(
+                       array(
+                               'id'          => 'demo',
+                               'name'        => __( 'Demo', 'wp-feature-api-agent' ),
+                               'description' => __( 'Features included with the WP Feature API demo.', 'wp-feature-api-agent' ),
+                               'features'    => array( 'demo/site-info' ),
+                       )
+               );
+        }
 
 	/**
 	 * Callback for the site info feature.

--- a/demo/wp-feature-api-agent/src/agent/wp-feature-tool-provider.ts
+++ b/demo/wp-feature-api-agent/src/agent/wp-feature-tool-provider.ts
@@ -36,8 +36,10 @@ export const createWpFeatureToolProvider = (): ToolProvider => {
 	 */
 	const getTools = async (): Promise< Tool[] > => {
 		try {
-			// Fetch all registered features using the API
-			const features: Feature[] | null = await getRegisteredFeatures();
+               // Fetch demo-specific features using the API
+               const features: Feature[] | null = await getRegisteredFeatures( {
+                       group: 'demo',
+               } );
 
 			if ( ! features ) {
 				// eslint-disable-next-line no-console

--- a/docs/7.client-side-features.md
+++ b/docs/7.client-side-features.md
@@ -53,7 +53,7 @@ Ensure this package is available and properly initialized in your client-side en
 
 ## Execution
 
-* **Client-to-Client:** Client-side code can directly discover and execute other registered client-side features using the `getRegisteredFeatures` and `executeFeature` functions from `@automattic/wp-feature-api`.
+* **Client-to-Client:** Client-side code can directly discover and execute other registered client-side features using the `getRegisteredFeatures( query? )` and `executeFeature` functions from `@automattic/wp-feature-api`.
 * **Server-Triggered Execution:** A purely server-side feature (PHP callback) *cannot* directly execute a client-side feature (JavaScript callback). However, a server-side process *can orchestrate* the execution of a client-side feature.
   * **Mechanism:**
         1. The server-side process (e.g., an AI agent interacting via the REST API, or a PHP request handler) discovers the client-side feature. This may require passing the allowed client-side features to the server-side process.

--- a/docs/for-ai.md
+++ b/docs/for-ai.md
@@ -115,7 +115,7 @@ The Feature API employs a registry pattern with distinct server-side and client-
 * **`store` (`@wordpress/data` store)**: Manages client-side feature state.
 * **`registerFeature( feature: Feature )`**: Registers a client-side feature.
 * **`executeFeature( featureId: string, args: any )`**: Executes a feature (client or server).
-* **`getRegisteredFeatures()`**: Retrieves all currently known features (client + resolved server).
+* **`getRegisteredFeatures( query? )`**: Retrieves features, optionally filtered using a query (e.g., `{ group: 'demo' }`).
 
     ```javascript
     // In your client-side code (e.g., block editor script)
@@ -164,9 +164,9 @@ The Feature API employs a registry pattern with distinct server-side and client-
         console.error('Error during update and save:', error);
       }
 
-      // Discover available features
-      const allFeatures = await getRegisteredFeatures();
-      console.log('Available Features:', allFeatures);
+      // Discover available features from the "demo" group
+      const allFeatures = await getRegisteredFeatures( { group: 'demo' } );
+      console.log('Demo Features:', allFeatures);
     }
     ```
 

--- a/includes/class-wp-feature-group.php
+++ b/includes/class-wp-feature-group.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * WP_Feature_Group class file.
+ *
+ * @package WordPress\Features_API
+ */
+
+/**
+ * Class WP_Feature_Group
+ *
+ * Represents a set of features in the WordPress Feature API.
+ *
+ * @since 0.1.0
+ */
+class WP_Feature_Group {
+
+    /**
+     * Group slug.
+     *
+     * @since 0.1.0
+     * @var string
+     */
+    private $slug;
+
+    /**
+     * Group name.
+     *
+     * @since 0.1.0
+     * @var string
+     */
+    private $name;
+
+    /**
+     * Group description.
+     *
+     * @since 0.1.0
+     * @var string
+     */
+    private $description = '';
+
+    /**
+     * Feature IDs that belong to this group.
+     *
+     * @since 0.1.0
+     * @var array
+     */
+    private $features = array();
+
+    /**
+     * Constructor.
+     *
+     * @since 0.1.0
+     * @param string|array $group Group data.
+     */
+    public function __construct( $group ) {
+        if ( is_string( $group ) ) {
+            $this->from_string( $group );
+        } elseif ( is_array( $group ) ) {
+            $this->from_array( $group );
+        }
+    }
+
+    /**
+     * Creates a group instance.
+     *
+     * @since 0.1.0
+     * @param string|array|WP_Feature_Group $group Group data.
+     * @return WP_Feature_Group|null Group instance or null on failure.
+     */
+    public static function make( $group ) {
+        if ( $group instanceof WP_Feature_Group ) {
+            return $group;
+        }
+
+        if ( is_string( $group ) || is_array( $group ) ) {
+            return new self( $group );
+        }
+
+        return null;
+    }
+
+    /**
+     * Gets the group slug.
+     *
+     * @since 0.1.0
+     * @return string
+     */
+    public function get_slug() {
+        return $this->slug;
+    }
+
+    /**
+     * Gets the group name.
+     *
+     * @since 0.1.0
+     * @return string
+     */
+    public function get_name() {
+        return $this->name;
+    }
+
+    /**
+     * Gets the group description.
+     *
+     * @since 0.1.0
+     * @return string
+     */
+    public function get_description() {
+        return $this->description;
+    }
+
+    /**
+     * Gets feature IDs for this group.
+     *
+     * @since 0.1.0
+     * @return array
+     */
+    public function get_features() {
+        return $this->features;
+    }
+
+    /**
+     * Converts the group to an array.
+     *
+     * @since 0.1.0
+     * @return array
+     */
+    public function to_array() {
+        return array(
+            'slug'        => $this->slug,
+            'name'        => $this->name,
+            'description' => $this->description,
+            'features'    => $this->features,
+        );
+    }
+
+    /**
+     * Creates a group instance from a string.
+     *
+     * @since 0.1.0
+     * @param string $group Group slug.
+     */
+    private function from_string( $group ) {
+        $this->slug        = sanitize_key( $group );
+        $this->name        = ucwords( str_replace( array( '-', '_' ), ' ', $this->slug ) );
+        $this->description = '';
+        $this->features    = array();
+    }
+
+    /**
+     * Creates a group instance from an array.
+     *
+     * @since 0.1.0
+     * @param array $group Group data.
+     */
+    private function from_array( $group ) {
+        if ( ! isset( $group['id'] ) ) {
+            return;
+        }
+
+        $this->slug        = sanitize_key( $group['id'] );
+        $this->name        = isset( $group['name'] ) ? sanitize_text_field( $group['name'] ) : ucwords( str_replace( array( '-', '_' ), ' ', $this->slug ) );
+        $this->description = isset( $group['description'] ) ? sanitize_text_field( $group['description'] ) : '';
+        $this->features    = isset( $group['features'] ) && is_array( $group['features'] ) ? array_values( $group['features'] ) : array();
+    }
+}

--- a/includes/class-wp-feature-query.php
+++ b/includes/class-wp-feature-query.php
@@ -33,13 +33,14 @@ class WP_Feature_Query {
 			array(
 				'type'       => array(),
 				'categories' => array(),
-				'location'   => array(),
-				'input_schema' => array(),
-				'output_schema' => array(),
-				'search'     => '',
-			)
-		);
-	}
+                               'location'   => array(),
+                               'input_schema' => array(),
+                               'output_schema' => array(),
+                               'group'      => '',
+                               'search'     => '',
+                       )
+               );
+       }
 
 	/**
 	 * Get the schema for the query.
@@ -92,31 +93,35 @@ class WP_Feature_Query {
 					),
 				),
 			),
-			'output_schema' => array(
-				'description' => __( 'Filter features by their output schema.', 'features-api' ),
-				'type' => 'object',
-				'properties' => array(
-					'match' => array(
-						'type' => 'string',
-						'enum' => array( 'all', 'any' ),
-						'default' => 'any',
-					),
-					'fields' => array(
-						'type' => 'array',
-						'items' => array(
-							'type' => 'string',
-						),
-					),
-					'required' => array(
-						'fields',
-					),
-				),
-			),
-			'search' => array(
-				'description' => __( 'Search features by name, description, or ID.', 'features-api' ),
-				'type' => 'string',
-			),
-		);
+                       'output_schema' => array(
+                               'description' => __( 'Filter features by their output schema.', 'features-api' ),
+                               'type' => 'object',
+                               'properties' => array(
+                                       'match' => array(
+                                               'type' => 'string',
+                                               'enum' => array( 'all', 'any' ),
+                                               'default' => 'any',
+                                       ),
+                                       'fields' => array(
+                                               'type' => 'array',
+                                               'items' => array(
+                                                       'type' => 'string',
+                                               ),
+                                       ),
+                                       'required' => array(
+                                               'fields',
+                                       ),
+                               ),
+                       ),
+                       'group' => array(
+                               'description' => __( 'Filter features by their group.', 'features-api' ),
+                               'type'        => 'string',
+                       ),
+                       'search' => array(
+                               'description' => __( 'Search features by name, description, or ID.', 'features-api' ),
+                               'type' => 'string',
+                       ),
+               );
 	}
 
 	/**
@@ -147,16 +152,27 @@ class WP_Feature_Query {
 			return false;
 		}
 
-		// Check categories.
-		if ( ! empty( $this->args['categories'] ) ) {
-			$feature_categories = $feature->get_categories();
-			$matches_category   = true;
-			foreach ( $this->args['categories'] as $category ) {
-				if ( ! in_array( $category, $feature_categories, true ) ) {
-					return false;
-				}
-			}
-		}
+               // Check categories.
+               if ( ! empty( $this->args['categories'] ) ) {
+                       $feature_categories = $feature->get_categories();
+                       $matches_category   = true;
+                       foreach ( $this->args['categories'] as $category ) {
+                               if ( ! in_array( $category, $feature_categories, true ) ) {
+                                       return false;
+                               }
+                       }
+               }
+
+               // Check group.
+               if ( ! empty( $this->args['group'] ) ) {
+                       $group = wp_feature_registry()->get_group( $this->args['group'] );
+                       if ( ! $group ) {
+                               return false;
+                       }
+                       if ( ! in_array( $feature->get_id(), $group->get_features(), true ) ) {
+                               return false;
+                       }
+               }
 
 		// Check input schema.
 		if ( ! empty( $this->args['input_schema'] ) ) {

--- a/includes/class-wp-feature-registry.php
+++ b/includes/class-wp-feature-registry.php
@@ -37,15 +37,23 @@ class WP_Feature_Registry {
 	 * @since 0.1.0
 	 * @var array
 	 */
-	private $features = array();
+       private $features = array();
 
-	/**
-	 * The categories collection.
-	 *
-	 * @since 0.1.0
-	 * @var WP_Feature_Categories
-	 */
-	private $categories = null;
+       /**
+        * The categories collection.
+        *
+        * @since 0.1.0
+        * @var WP_Feature_Categories
+        */
+       private $categories = null;
+
+       /**
+        * Registered feature groups.
+        *
+        * @since 0.1.0
+        * @var array
+        */
+       private $groups = array();
 
 	/**
 	 * Private constructor to prevent direct instantiation.
@@ -56,8 +64,9 @@ class WP_Feature_Registry {
 	private function __construct() {
 		require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/interface-wp-feature-repository.php';
 		require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-repository-memory.php';
-		require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-category.php';
-		require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-categories.php';
+               require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-category.php';
+               require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-categories.php';
+               require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-group.php';
 
 		$default_repository = new WP_Feature_Repository_Memory();
 		$repository = apply_filters( 'wp_feature_repository', $default_repository );
@@ -271,9 +280,49 @@ class WP_Feature_Registry {
 	 * @param string $id The category ID.
 	 * @return WP_Feature_Category|null The category if found, null otherwise.
 	 */
-	public function get_category( $id ) {
-		return $this->categories->get( $id );
-	}
+        public function get_category( $id ) {
+                return $this->categories->get( $id );
+        }
+
+       /**
+        * Registers a feature group.
+        *
+        * @since 0.1.0
+        * @param WP_Feature_Group|array|string $group Group data.
+        * @return bool True on success, false otherwise.
+        */
+       public function register_group( $group ) {
+               $group_obj = WP_Feature_Group::make( $group );
+
+               if ( ! $group_obj ) {
+                       return false;
+               }
+
+               $this->groups[ $group_obj->get_slug() ] = $group_obj;
+
+               return true;
+       }
+
+       /**
+        * Gets a feature group by slug.
+        *
+        * @since 0.1.0
+        * @param string $slug Group slug.
+        * @return WP_Feature_Group|null Group object or null if not found.
+        */
+       public function get_group( $slug ) {
+               return isset( $this->groups[ $slug ] ) ? $this->groups[ $slug ] : null;
+       }
+
+       /**
+        * Gets all registered groups.
+        *
+        * @since 0.1.0
+        * @return array
+        */
+       public function get_groups() {
+               return $this->groups;
+       }
 
 	/**
 	 * Removes a feature from the repository and cache.

--- a/includes/load.php
+++ b/includes/load.php
@@ -11,6 +11,8 @@ require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-registry.php
 require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature.php';
 // Include the WP_Feature_Query class.
 require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-query.php';
+// Include the WP_Feature_Group class.
+require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/class-wp-feature-group.php';
 // Include global functions.
 require_once WP_FEATURE_API_PLUGIN_DIR . 'includes/wp-feature.php';
 // Initialize the REST API endpoints.

--- a/includes/wp-feature.php
+++ b/includes/wp-feature.php
@@ -23,7 +23,18 @@ function wp_feature_registry() {
  * @return bool True if the feature was registered, false otherwise.
  */
 function wp_register_feature( $feature ) {
-	return wp_feature_registry()->register( $feature );
+        return wp_feature_registry()->register( $feature );
+}
+
+/**
+ * Registers a feature group.
+ *
+ * @since 0.1.0
+ * @param WP_Feature_Group|array|string $group Group data.
+ * @return bool True if the group was registered, false otherwise.
+ */
+function wp_register_feature_group( $group ) {
+       return wp_feature_registry()->register_group( $group );
 }
 
 /**

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -45,9 +45,11 @@ export function getRegisteredFeature( featureId: string ): Feature | null {
  *
  * @return An array of all registered feature definition objects, or null if the store is not ready.
  */
-export async function getRegisteredFeatures(): Promise< Feature[] | null > {
-	const features = await resolveSelect( store )?.getRegisteredFeatures();
-	return features || null;
+export async function getRegisteredFeatures(
+       query: Record< string, unknown > = {}
+): Promise< Feature[] | null > {
+       const features = await resolveSelect( store )?.getRegisteredFeatures( query );
+       return features || null;
 }
 
 /**

--- a/packages/client/src/store/resolvers.ts
+++ b/packages/client/src/store/resolvers.ts
@@ -10,13 +10,13 @@ import { ENTITY_KIND, ENTITY_NAME } from './constants';
 import { receiveFeatures, receiveFeature } from './actions';
 import { store } from './index';
 
-export function getRegisteredFeatures() {
-	return async ( { dispatch, registry } ) => {
-		const features = await registry
-			.resolveSelect( coreStore )
-			.getEntityRecords( ENTITY_KIND, ENTITY_NAME );
-		dispatch( receiveFeatures( features ) );
-	};
+export function getRegisteredFeatures( query: Record< string, unknown > = {} ) {
+       return async ( { dispatch, registry } ) => {
+               const features = await registry
+                       .resolveSelect( coreStore )
+                       .getEntityRecords( ENTITY_KIND, ENTITY_NAME, query );
+               dispatch( receiveFeatures( features ) );
+       };
 }
 
 export function getRegisteredFeature( id: string ) {


### PR DESCRIPTION
## Summary
- add a demo feature group registration and export only demo group features
- expose optional query argument in `getRegisteredFeatures` on the client
- document feature groups in the README and docs
- showcase grouped features in the agent provider

## Testing
- `npm run test:unit:php` *(fails: `npm-run-all: not found`)*