### PR TITLE
Implement feature versioning support

### DIFF
--- a/demo/wp-feature-api-agent/README.md
+++ b/demo/wp-feature-api-agent/README.md
@@ -1,6 +1,6 @@
 # WordPress Feature API Demo
 
-This demo plugin showcases how to use the WordPress Feature API, including registering features, and implementing WP Features as tools in a Typescript based AI Agent.
+This demo plugin showcases how to use the WordPress Feature API, including registering versioned features and implementing WP Features as tools in a TypeScript based AI Agent.
 
 ## Usage
 
@@ -12,3 +12,5 @@ This demo plugin showcases how to use the WordPress Feature API, including regis
 4. Navigate to "Settings" -> "WP Feature Agent Demo" in the WordPress admin to configure your OpenAI API key.
 5. Refresh and see the AI Agent chat interface.
 6. Ask the AI Agent questions about your WordPress site and features. It has access to both server-side and client-side features.
+
+The `demo/site-info` feature is registered with multiple versions. Version `2.0.0` adds extra details like the site's character set and post count.

--- a/demo/wp-feature-api-agent/includes/class-wp-feature-register.php
+++ b/demo/wp-feature-api-agent/includes/class-wp-feature-register.php
@@ -30,17 +30,30 @@ class WP_Feature_Register {
 	 */
 	public function register_features() {
 		/** Global Features */
-		wp_register_feature(
-			array(
-				'id'          => 'demo/site-info',
-				'name'        => __( 'Site Information', 'wp-feature-api-agent' ),
-				'description' => __( 'Get basic information about the WordPress site. This includes the name, description, URL, version, language, timezone, date format, time format, active plugins, and active theme.', 'wp-feature-api-agent' ),
-				'type'        => WP_Feature::TYPE_RESOURCE,
-				'categories'  => array( 'demo', 'site', 'information' ),
-				'callback'    => array( $this, 'site_info_callback' ),
-			)
-		);
-	}
+               wp_register_feature(
+                       array(
+                               'id'                => 'demo/site-info',
+                               'name'              => __( 'Site Information', 'wp-feature-api-agent' ),
+                               'description'       => __( 'Get basic information about the WordPress site. This includes the name, description, URL, version, language, timezone, date format, time format, active plugins, and active theme.', 'wp-feature-api-agent' ),
+                               'type'              => WP_Feature::TYPE_RESOURCE,
+                               'categories'        => array( 'demo', 'site', 'information' ),
+                               'version'           => '2.0.0',
+                               'since_version'     => '1.0.0',
+                               'deprecated_version'=> '3.0.0',
+                               'alternatives'      => array(),
+                               'deprecated_message'=> __( 'Use the latest version of this feature for more details.', 'wp-feature-api-agent' ),
+                               'versions'          => array(
+                                       '1.0.0' => array(
+                                               'callback' => array( $this, 'site_info_callback' ),
+                                       ),
+                                       '2.0.0' => array(
+                                               'callback' => array( $this, 'site_info_v2_callback' ),
+                                       ),
+                               ),
+                               'callback'          => array( $this, 'site_info_v2_callback' ),
+                       )
+               );
+       }
 
 	/**
 	 * Callback for the site info feature.
@@ -48,18 +61,31 @@ class WP_Feature_Register {
 	 * @param array $input Input parameters for the feature.
 	 * @return array Site information.
 	 */
-	public function site_info_callback( $input ) {
-		return array(
-			'name'        => get_bloginfo( 'name' ),
-			'description' => get_bloginfo( 'description' ),
-			'url'         => home_url(),
-			'version'     => get_bloginfo( 'version' ),
-			'language'    => get_bloginfo( 'language' ),
-			'timezone'    => wp_timezone_string(),
-			'date_format' => get_option( 'date_format' ),
-			'time_format' => get_option( 'time_format' ),
-			'active_plugins' => get_option( 'active_plugins' ),
-			'active_theme' => get_option( 'stylesheet' ),
-		);
-	}
+        public function site_info_callback( $input ) {
+                return array(
+                        'name'        => get_bloginfo( 'name' ),
+                        'description' => get_bloginfo( 'description' ),
+                        'url'         => home_url(),
+                        'version'     => get_bloginfo( 'version' ),
+                        'language'    => get_bloginfo( 'language' ),
+                        'timezone'    => wp_timezone_string(),
+                        'date_format' => get_option( 'date_format' ),
+                        'time_format' => get_option( 'time_format' ),
+                        'active_plugins' => get_option( 'active_plugins' ),
+                        'active_theme' => get_option( 'stylesheet' ),
+                );
+        }
+
+       /**
+        * Callback for version 2 of the site info feature.
+        *
+        * @param array $input Input parameters for the feature.
+        * @return array Extended site information.
+        */
+       public function site_info_v2_callback( $input ) {
+               $info = $this->site_info_callback( $input );
+               $info['charset'] = get_option( 'blog_charset' );
+               $info['posts_count'] = (int) wp_count_posts()->publish;
+               return $info;
+       }
 }

--- a/docs/11.demo.md
+++ b/docs/11.demo.md
@@ -31,18 +31,29 @@ The demo follows a clean architecture pattern divided into several key component
 
 ### Server-Side Features
 
-The demo registers a simple server-side resource feature:
+The demo registers a versioned server-side resource feature:
 
 ```php
 // In includes/class-wp-feature-register.php
 wp_register_feature(
     array(
-        'id'          => 'demo/site-info',
-        'name'        => __( 'Site Information', 'wp-feature-api-agent' ),
-        'description' => __( 'Get basic information about the WordPress site. This includes the name, description, URL, version, language, timezone, date format, time format, active plugins, and active theme.', 'wp-feature-api-agent' ),
-        'type'        => WP_Feature::TYPE_RESOURCE,
-        'categories'  => array( 'demo', 'site', 'information' ),
-        'callback'    => array( $this, 'site_info_callback' ),
+        'id'                => 'demo/site-info',
+        'name'              => __( 'Site Information', 'wp-feature-api-agent' ),
+        'description'       => __( 'Get basic information about the WordPress site. This includes the name, description, URL, version, language, timezone, date format, time format, active plugins, and active theme.', 'wp-feature-api-agent' ),
+        'type'              => WP_Feature::TYPE_RESOURCE,
+        'categories'        => array( 'demo', 'site', 'information' ),
+        'version'           => '2.0.0',
+        'since_version'     => '1.0.0',
+        'deprecated_version'=> '3.0.0',
+        'versions'          => array(
+            '1.0.0' => array(
+                'callback' => array( $this, 'site_info_callback' ),
+            ),
+            '2.0.0' => array(
+                'callback' => array( $this, 'site_info_v2_callback' ),
+            ),
+        ),
+        'callback'          => array( $this, 'site_info_v2_callback' ),
     )
 );
 ```

--- a/includes/class-wp-feature.php
+++ b/includes/class-wp-feature.php
@@ -178,7 +178,55 @@ class WP_Feature implements \JsonSerializable {
 	 * @since 0.1.0
 	 * @var array
 	 */
-	private $location;
+        private $location;
+
+       /**
+        * Current version of the feature.
+        *
+        * @since 0.1.0
+        * @var string
+        */
+       private $version = '';
+
+       /**
+        * Version when this feature becomes deprecated.
+        *
+        * @since 0.1.0
+        * @var string
+        */
+       private $deprecated_version = '';
+
+       /**
+        * Version when this feature was introduced.
+        *
+        * @since 0.1.0
+        * @var string
+        */
+       private $since_version = '';
+
+       /**
+        * Alternative feature IDs.
+        *
+        * @since 0.1.0
+        * @var array
+        */
+       private $alternatives = array();
+
+       /**
+        * Message explaining why the feature is deprecated.
+        *
+        * @since 0.1.0
+        * @var string
+        */
+       private $deprecated_message = '';
+
+       /**
+        * Mapping of available versions to their specific args.
+        *
+        * @since 0.1.0
+        * @var array
+        */
+       private $versions = array();
 
 	/**
 	 * Constructor.
@@ -398,9 +446,59 @@ class WP_Feature implements \JsonSerializable {
 	 * @since 0.1.0
 	 * @return array The feature location.
 	 */
-	public function get_location() {
-		return self::LOCATION_SERVER;
-	}
+        public function get_location() {
+                return self::LOCATION_SERVER;
+        }
+
+       /**
+        * Gets the feature version.
+        *
+        * @since 0.1.0
+        * @return string Version string.
+        */
+       public function get_version() {
+               return $this->version;
+       }
+
+       /**
+        * Gets the deprecated version string.
+        *
+        * @since 0.1.0
+        * @return string Deprecated version.
+        */
+       public function get_deprecated_version() {
+               return $this->deprecated_version;
+       }
+
+       /**
+        * Gets the version when the feature was introduced.
+        *
+        * @since 0.1.0
+        * @return string Since version.
+        */
+       public function get_since_version() {
+               return $this->since_version;
+       }
+
+       /**
+        * Gets the message explaining deprecation.
+        *
+        * @since 0.1.0
+        * @return string Deprecation message.
+        */
+       public function get_deprecated_message() {
+               return $this->deprecated_message;
+       }
+
+       /**
+        * Gets defined versions.
+        *
+        * @since 0.1.0
+        * @return array Versions map.
+        */
+       public function get_versions() {
+               return $this->versions;
+       }
 
 	/**
 	 * Whether the feature has a REST alias.
@@ -454,9 +552,9 @@ class WP_Feature implements \JsonSerializable {
 		}
 
 		// Validate the input against the schema if available.
-		if ( ! empty( $this->input_schema ) ) {
-			$valid = $this->validate_input( $context );
-			if ( is_wp_error( $valid ) ) {
+                if ( ! empty( $this->input_schema ) ) {
+                        $valid = $this->validate_input( $context );
+                        if ( is_wp_error( $valid ) ) {
 				/**
 				 * Fires when input validation fails for a feature.
 				 *
@@ -467,9 +565,27 @@ class WP_Feature implements \JsonSerializable {
 				 */
 				do_action( 'wp_feature_input_validation_failed', $valid, $context, $this );
 				do_action( $this->get_filter_id() . '_input_validation_failed', $valid, $context, $this );
-				return $valid;
-			}
-		}
+                                return $valid;
+                        }
+                }
+
+               if ( $this->isDeprecated() ) {
+                       /**
+                        * Fires when a deprecated feature version is executed.
+                        *
+                        * @since 0.1.0
+                        * @param string $feature_id        The feature ID.
+                        * @param string $version_used      The version being used.
+                        * @param string $deprecated_version The version marked deprecated.
+                        * @param array  $alternatives       Suggested alternatives.
+                        */
+                       do_action( 'wp_feature_deprecated_run', $this->get_id(), $this->version, $this->deprecated_version, $this->alternatives );
+
+                       $should_run = apply_filters( 'wp_feature_handle_deprecated', true, $this->version, $this );
+                       if ( ! $should_run ) {
+                               return new WP_Error( 'deprecated_feature', __( 'This feature version is deprecated.', 'wp-feature-api' ) );
+                       }
+               }
 
 		/**
 		 * Fires before a feature is run.
@@ -542,20 +658,26 @@ class WP_Feature implements \JsonSerializable {
 	private function set_props( $args ) {
 		$args = wp_parse_args(
 			$args,
-			array(
-				'type'         => self::TYPE_DEFAULT,
-				'name'         => '',
-				'description'  => '',
-				'meta'         => array(),
-				'categories'   => array(),
-				'input_schema' => array(),
-				'output_schema' => array(),
-				'callback'     => null,
-				'permission_callback' => null,
-				'is_eligible'       => null,
-				'rest_alias'   => false,
-			)
-		);
+                       array(
+                               'type'               => self::TYPE_DEFAULT,
+                               'name'               => '',
+                               'description'        => '',
+                               'meta'               => array(),
+                               'categories'         => array(),
+                               'input_schema'       => array(),
+                               'output_schema'      => array(),
+                               'callback'           => null,
+                               'permission_callback' => null,
+                               'is_eligible'        => null,
+                               'rest_alias'         => false,
+                               'version'            => '',
+                               'deprecated_version' => '',
+                               'since_version'      => '',
+                               'alternatives'       => array(),
+                               'deprecated_message' => '',
+                               'versions'           => array(),
+                       )
+               );
 
 		if ( empty( $args['name'] ) ) {
 			return new WP_Error( 'missing_name', __( 'Feature name is required.', 'wp-feature-api' ) );
@@ -581,8 +703,8 @@ class WP_Feature implements \JsonSerializable {
 		$this->description = sanitize_text_field( $args['description'] );
 		$this->type        = $args['type'];
 
-		// Meta should be an array.
-		$this->meta = is_array( $args['meta'] ) ? $args['meta'] : array();
+               // Meta should be an array.
+               $this->meta = is_array( $args['meta'] ) ? $args['meta'] : array();
 
 		// Categories should be an array.
 		$this->categories = is_array( $args['categories'] ) ? $args['categories'] : array();
@@ -600,11 +722,39 @@ class WP_Feature implements \JsonSerializable {
 		// Filter must be callable or null.
 		$this->is_eligible = is_callable( $args['is_eligible'] ) || null === $args['is_eligible'] ? $args['is_eligible'] : null;
 
-		// Rest alias must be false or a string.
-		$this->rest_alias = false === $args['rest_alias'] || is_string( $args['rest_alias'] ) ? $args['rest_alias'] : false;
 
-		return true;
-	}
+               // Rest alias must be false or a string.
+               $this->rest_alias = false === $args['rest_alias'] || is_string( $args['rest_alias'] ) ? $args['rest_alias'] : false;
+
+               // Versioning fields.
+               $this->version            = sanitize_text_field( $args['version'] );
+               $this->deprecated_version = sanitize_text_field( $args['deprecated_version'] );
+               $this->since_version      = sanitize_text_field( $args['since_version'] );
+               $this->alternatives       = is_array( $args['alternatives'] ) ? $args['alternatives'] : array();
+               $this->deprecated_message = sanitize_text_field( $args['deprecated_message'] );
+               $this->versions           = is_array( $args['versions'] ) ? $args['versions'] : array();
+
+               if ( empty( $this->version ) && ! empty( $this->versions ) ) {
+                       $vers = array_keys( $this->versions );
+                       usort( $vers, 'version_compare' );
+                       $this->version = end( $vers );
+               }
+
+               if ( ! empty( $this->versions ) && isset( $this->versions[ $this->version ] ) ) {
+                       $ver_args = $this->versions[ $this->version ];
+                       if ( isset( $ver_args['input_schema'] ) ) {
+                               $this->input_schema = $ver_args['input_schema'];
+                       }
+                       if ( isset( $ver_args['output_schema'] ) ) {
+                               $this->output_schema = $ver_args['output_schema'];
+                       }
+                       if ( isset( $ver_args['callback'] ) && is_callable( $ver_args['callback'] ) ) {
+                               $this->callback = $ver_args['callback'];
+                       }
+               }
+
+               return true;
+       }
 
 
 	/**
@@ -672,10 +822,16 @@ class WP_Feature implements \JsonSerializable {
 			'type'          => $this->type,
 			'meta'          => $this->meta,
 			'categories'    => $this->categories,
-			'input_schema'  => $this->get_input_schema(),
-			'output_schema' => $this->get_output_schema(),
-			'location'      => $this->get_location(),
-		);
+                       'input_schema'  => $this->get_input_schema(),
+                       'output_schema' => $this->get_output_schema(),
+                       'location'      => $this->get_location(),
+                       'version'            => $this->version,
+                       'since_version'      => $this->since_version,
+                       'deprecated_version' => $this->deprecated_version,
+                       'alternatives'       => $this->alternatives,
+                       'deprecated_message' => $this->deprecated_message,
+                       'versions'           => $this->versions,
+               );
 
 		/**
 		 * Filters the feature data when converting to an array.
@@ -716,18 +872,42 @@ class WP_Feature implements \JsonSerializable {
 	 * @since 0.1.0
 	 * @return array The alternate types.
 	 */
-	public function get_alternate_types() {
-		$alternate_types = array_diff( self::TYPES, array( $this->type ) );
-		$alternate_features = array();
-		foreach ( $alternate_types as $type ) {
-			$feature = wp_feature_registry()->find( $this->id, $type );
-			if ( $feature instanceof WP_Feature ) {
-				$alternate_features[] = $feature;
-			}
-		}
+       public function get_alternate_types() {
+               $alternate_types = array_diff( self::TYPES, array( $this->type ) );
+               $alternate_features = array();
+               foreach ( $alternate_types as $type ) {
+                       $feature = wp_feature_registry()->find( $this->id, $type );
+                       if ( $feature instanceof WP_Feature ) {
+                               $alternate_features[] = $feature;
+                       }
+               }
 
-		return $alternate_features;
-	}
+               return $alternate_features;
+       }
+
+       /**
+        * Determines if the current version is deprecated.
+        *
+        * @since 0.1.0
+        * @return bool Whether the feature is deprecated.
+        */
+       public function isDeprecated() {
+               if ( empty( $this->deprecated_version ) ) {
+                       return false;
+               }
+
+               return version_compare( $this->version, $this->deprecated_version, '>=' );
+       }
+
+       /**
+        * Gets the alternative feature IDs.
+        *
+        * @since 0.1.0
+        * @return array Alternative feature IDs.
+        */
+       public function getAlternatives() {
+               return $this->alternatives;
+       }
 
 	/**
 	 * Sets the feature from a REST alias.

--- a/includes/rest-api/class-wp-rest-feature-controller.php
+++ b/includes/rest-api/class-wp-rest-feature-controller.php
@@ -203,12 +203,21 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 
 		$response = rest_ensure_response( $data );
 		$links = $this->get_links( $feature );
-		if ( ! empty( $links ) ) {
-			$response->add_links( $links );
-		}
+               if ( ! empty( $links ) ) {
+                       $response->add_links( $links );
+               }
 
-		return $response;
-	}
+               /**
+                * Filter the REST response for a feature.
+                *
+                * @since 0.1.0
+                * @param WP_REST_Response $response The response object.
+                * @param WP_Feature       $feature  The feature object.
+                */
+               $response = apply_filters( 'wp_feature_rest_response', $response, $feature );
+
+               return $response;
+       }
 
 	/**
 	 * Retrieves the query params for collections.


### PR DESCRIPTION
## Summary
- update demo to register a versioned `demo/site-info` feature
- document version support in `docs/11.demo.md`
- mention versioned feature in demo README

## Testing
- `npx wp-scripts lint-js` *(fails: connect EHOSTUNREACH)*