### PR TITLE
Add version and deprecation support

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -263,14 +263,14 @@ const feature = wp.features.find('woocommerce/product/report', {
 });
 
 // Check if feature is deprecated
-if (feature.isDeprecated()) {
+if (feature.is_deprecated()) {
 	console.warn(
 		`Feature ${feature.id} is deprecated. ${feature.deprecated_message}`
 	);
 }
 
 // Get suggested alternatives
-const alternatives = feature.getAlternatives();
+const alternatives = feature.get_alternatives();
 ```
 
 Notify or quiet deprecation:
@@ -310,7 +310,7 @@ Add version information to REST response headers:
 // Add version information to REST response headers
 add_filter('wp_feature_rest_response', function($response, $feature) {
     $response->header('X-WP-Feature-Version', $feature->version);
-    if ($feature->isDeprecated()) {
+    if ($feature->is_deprecated()) {
         $response->header('X-WP-Feature-Deprecated', 'true');
         $response->header('X-WP-Feature-Alternatives', implode(',', $feature->alternatives));
     }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,36 @@ Filtering can be done by:
 - `is_eligible` boolean callback
 - Context matching for when we already have some context and want Features that can be fulfilled using that context.
 
+## Feature Versioning and Deprecation
+
+Features can evolve over time. Provide `version` metadata when registering a feature and optionally set `deprecated_version`, `alternatives`, and a `versions` map for version-specific behavior.
+
+```php
+wp_register_feature( 'my-plugin/report', array(
+    'name'        => 'Report',
+    'description' => 'Generates a report.',
+    'version'     => '2.0.0',
+    'deprecated_version' => '3.0.0',
+    'alternatives' => array( 'my-plugin/new-report' ),
+    'versions'    => array(
+        '1.0.0' => array(
+            'callback' => 'my_plugin_report_v1',
+        ),
+        '2.0.0' => array(
+            'callback' => 'my_plugin_report_v2',
+        ),
+    ),
+) );
+```
+
+Deprecated execution triggers the `wp_feature_deprecated_run` action. Use the `wp_feature_handle_deprecated` filter to prevent running outdated versions. The `wp_feature_rest_response` filter can add custom headers with version information.
+
+```php
+if ( $feature->is_deprecated() ) {
+    $alternatives = $feature->get_alternatives();
+}
+```
+
 ## Getting Started
 
 ### Development

--- a/includes/class-wp-feature.php
+++ b/includes/class-wp-feature.php
@@ -178,7 +178,55 @@ class WP_Feature implements \JsonSerializable {
 	 * @since 0.1.0
 	 * @var array
 	 */
-	private $location;
+        private $location;
+
+       /**
+        * Current version of the feature.
+        *
+        * @since 0.1.0
+        * @var string
+        */
+       private $version = '';
+
+       /**
+        * Version when this feature becomes deprecated.
+        *
+        * @since 0.1.0
+        * @var string
+        */
+       private $deprecated_version = '';
+
+       /**
+        * Version when this feature was introduced.
+        *
+        * @since 0.1.0
+        * @var string
+        */
+       private $since_version = '';
+
+       /**
+        * Alternative feature IDs.
+        *
+        * @since 0.1.0
+        * @var array
+        */
+       private $alternatives = array();
+
+       /**
+        * Message explaining why the feature is deprecated.
+        *
+        * @since 0.1.0
+        * @var string
+        */
+       private $deprecated_message = '';
+
+       /**
+        * Mapping of available versions to their specific args.
+        *
+        * @since 0.1.0
+        * @var array
+        */
+       private $versions = array();
 
 	/**
 	 * Constructor.
@@ -398,9 +446,59 @@ class WP_Feature implements \JsonSerializable {
 	 * @since 0.1.0
 	 * @return array The feature location.
 	 */
-	public function get_location() {
-		return self::LOCATION_SERVER;
-	}
+        public function get_location() {
+                return self::LOCATION_SERVER;
+        }
+
+       /**
+        * Gets the feature version.
+        *
+        * @since 0.1.0
+        * @return string Version string.
+        */
+       public function get_version() {
+               return $this->version;
+       }
+
+       /**
+        * Gets the deprecated version string.
+        *
+        * @since 0.1.0
+        * @return string Deprecated version.
+        */
+       public function get_deprecated_version() {
+               return $this->deprecated_version;
+       }
+
+       /**
+        * Gets the version when the feature was introduced.
+        *
+        * @since 0.1.0
+        * @return string Since version.
+        */
+       public function get_since_version() {
+               return $this->since_version;
+       }
+
+       /**
+        * Gets the message explaining deprecation.
+        *
+        * @since 0.1.0
+        * @return string Deprecation message.
+        */
+       public function get_deprecated_message() {
+               return $this->deprecated_message;
+       }
+
+       /**
+        * Gets defined versions.
+        *
+        * @since 0.1.0
+        * @return array Versions map.
+        */
+       public function get_versions() {
+               return $this->versions;
+       }
 
 	/**
 	 * Whether the feature has a REST alias.
@@ -454,9 +552,9 @@ class WP_Feature implements \JsonSerializable {
 		}
 
 		// Validate the input against the schema if available.
-		if ( ! empty( $this->input_schema ) ) {
-			$valid = $this->validate_input( $context );
-			if ( is_wp_error( $valid ) ) {
+                if ( ! empty( $this->input_schema ) ) {
+                        $valid = $this->validate_input( $context );
+                        if ( is_wp_error( $valid ) ) {
 				/**
 				 * Fires when input validation fails for a feature.
 				 *
@@ -467,9 +565,38 @@ class WP_Feature implements \JsonSerializable {
 				 */
 				do_action( 'wp_feature_input_validation_failed', $valid, $context, $this );
 				do_action( $this->get_filter_id() . '_input_validation_failed', $valid, $context, $this );
-				return $valid;
-			}
-		}
+                                return $valid;
+                        }
+                }
+
+               if ( $this->is_deprecated() ) {
+                       /**
+                        * Fires when a deprecated feature version is executed.
+                        *
+                        * @since 0.1.0
+                        * @param string $feature_id        The feature ID.
+                        * @param string $version_used      The version being used.
+                        * @param string $deprecated_version The version marked deprecated.
+                        * @param array  $alternatives       Suggested alternatives.
+                        */
+                       do_action( 'wp_feature_deprecated_run', $this->get_id(), $this->version, $this->deprecated_version, $this->alternatives );
+
+                       /**
+                        * Filters whether a deprecated feature should run.
+                        *
+                        * Allows plugins to block execution of deprecated versions or modify behavior.
+                        *
+                        * @since 0.1.0
+                        *
+                        * @param bool       $should_run    Whether the feature should run.
+                        * @param string     $version_used  The version being executed.
+                        * @param WP_Feature $feature       The feature object.
+                        */
+                       $should_run = apply_filters( 'wp_feature_handle_deprecated', true, $this->version, $this );
+                       if ( ! $should_run ) {
+                               return new WP_Error( 'deprecated_feature', __( 'This feature version is deprecated.', 'wp-feature-api' ) );
+                       }
+               }
 
 		/**
 		 * Fires before a feature is run.
@@ -542,20 +669,26 @@ class WP_Feature implements \JsonSerializable {
 	private function set_props( $args ) {
 		$args = wp_parse_args(
 			$args,
-			array(
-				'type'         => self::TYPE_DEFAULT,
-				'name'         => '',
-				'description'  => '',
-				'meta'         => array(),
-				'categories'   => array(),
-				'input_schema' => array(),
-				'output_schema' => array(),
-				'callback'     => null,
-				'permission_callback' => null,
-				'is_eligible'       => null,
-				'rest_alias'   => false,
-			)
-		);
+                       array(
+                               'type'               => self::TYPE_DEFAULT,
+                               'name'               => '',
+                               'description'        => '',
+                               'meta'               => array(),
+                               'categories'         => array(),
+                               'input_schema'       => array(),
+                               'output_schema'      => array(),
+                               'callback'           => null,
+                               'permission_callback' => null,
+                               'is_eligible'        => null,
+                               'rest_alias'         => false,
+                               'version'            => '',
+                               'deprecated_version' => '',
+                               'since_version'      => '',
+                               'alternatives'       => array(),
+                               'deprecated_message' => '',
+                               'versions'           => array(),
+                       )
+               );
 
 		if ( empty( $args['name'] ) ) {
 			return new WP_Error( 'missing_name', __( 'Feature name is required.', 'wp-feature-api' ) );
@@ -581,8 +714,8 @@ class WP_Feature implements \JsonSerializable {
 		$this->description = sanitize_text_field( $args['description'] );
 		$this->type        = $args['type'];
 
-		// Meta should be an array.
-		$this->meta = is_array( $args['meta'] ) ? $args['meta'] : array();
+               // Meta should be an array.
+               $this->meta = is_array( $args['meta'] ) ? $args['meta'] : array();
 
 		// Categories should be an array.
 		$this->categories = is_array( $args['categories'] ) ? $args['categories'] : array();
@@ -600,11 +733,39 @@ class WP_Feature implements \JsonSerializable {
 		// Filter must be callable or null.
 		$this->is_eligible = is_callable( $args['is_eligible'] ) || null === $args['is_eligible'] ? $args['is_eligible'] : null;
 
-		// Rest alias must be false or a string.
-		$this->rest_alias = false === $args['rest_alias'] || is_string( $args['rest_alias'] ) ? $args['rest_alias'] : false;
 
-		return true;
-	}
+               // Rest alias must be false or a string.
+               $this->rest_alias = false === $args['rest_alias'] || is_string( $args['rest_alias'] ) ? $args['rest_alias'] : false;
+
+               // Versioning fields.
+               $this->version            = sanitize_text_field( $args['version'] );
+               $this->deprecated_version = sanitize_text_field( $args['deprecated_version'] );
+               $this->since_version      = sanitize_text_field( $args['since_version'] );
+               $this->alternatives       = is_array( $args['alternatives'] ) ? $args['alternatives'] : array();
+               $this->deprecated_message = sanitize_text_field( $args['deprecated_message'] );
+               $this->versions           = is_array( $args['versions'] ) ? $args['versions'] : array();
+
+               if ( empty( $this->version ) && ! empty( $this->versions ) ) {
+                       $vers = array_keys( $this->versions );
+                       usort( $vers, 'version_compare' );
+                       $this->version = end( $vers );
+               }
+
+               if ( ! empty( $this->versions ) && isset( $this->versions[ $this->version ] ) ) {
+                       $ver_args = $this->versions[ $this->version ];
+                       if ( isset( $ver_args['input_schema'] ) ) {
+                               $this->input_schema = $ver_args['input_schema'];
+                       }
+                       if ( isset( $ver_args['output_schema'] ) ) {
+                               $this->output_schema = $ver_args['output_schema'];
+                       }
+                       if ( isset( $ver_args['callback'] ) && is_callable( $ver_args['callback'] ) ) {
+                               $this->callback = $ver_args['callback'];
+                       }
+               }
+
+               return true;
+       }
 
 
 	/**
@@ -672,10 +833,16 @@ class WP_Feature implements \JsonSerializable {
 			'type'          => $this->type,
 			'meta'          => $this->meta,
 			'categories'    => $this->categories,
-			'input_schema'  => $this->get_input_schema(),
-			'output_schema' => $this->get_output_schema(),
-			'location'      => $this->get_location(),
-		);
+                       'input_schema'  => $this->get_input_schema(),
+                       'output_schema' => $this->get_output_schema(),
+                       'location'      => $this->get_location(),
+                       'version'            => $this->version,
+                       'since_version'      => $this->since_version,
+                       'deprecated_version' => $this->deprecated_version,
+                       'alternatives'       => $this->alternatives,
+                       'deprecated_message' => $this->deprecated_message,
+                       'versions'           => $this->versions,
+               );
 
 		/**
 		 * Filters the feature data when converting to an array.
@@ -716,18 +883,42 @@ class WP_Feature implements \JsonSerializable {
 	 * @since 0.1.0
 	 * @return array The alternate types.
 	 */
-	public function get_alternate_types() {
-		$alternate_types = array_diff( self::TYPES, array( $this->type ) );
-		$alternate_features = array();
-		foreach ( $alternate_types as $type ) {
-			$feature = wp_feature_registry()->find( $this->id, $type );
-			if ( $feature instanceof WP_Feature ) {
-				$alternate_features[] = $feature;
-			}
-		}
+       public function get_alternate_types() {
+               $alternate_types = array_diff( self::TYPES, array( $this->type ) );
+               $alternate_features = array();
+               foreach ( $alternate_types as $type ) {
+                       $feature = wp_feature_registry()->find( $this->id, $type );
+                       if ( $feature instanceof WP_Feature ) {
+                               $alternate_features[] = $feature;
+                       }
+               }
 
-		return $alternate_features;
-	}
+               return $alternate_features;
+       }
+
+       /**
+        * Determines if the current version is deprecated.
+        *
+        * @since 0.1.0
+        * @return bool Whether the feature is deprecated.
+        */
+       public function is_deprecated() {
+               if ( empty( $this->deprecated_version ) ) {
+                       return false;
+               }
+
+               return version_compare( $this->version, $this->deprecated_version, '>=' );
+       }
+
+       /**
+        * Gets the alternative feature IDs.
+        *
+        * @since 0.1.0
+        * @return array Alternative feature IDs.
+        */
+       public function get_alternatives() {
+               return $this->alternatives;
+       }
 
 	/**
 	 * Sets the feature from a REST alias.

--- a/includes/rest-api/class-wp-rest-feature-controller.php
+++ b/includes/rest-api/class-wp-rest-feature-controller.php
@@ -203,12 +203,21 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 
 		$response = rest_ensure_response( $data );
 		$links = $this->get_links( $feature );
-		if ( ! empty( $links ) ) {
-			$response->add_links( $links );
-		}
+               if ( ! empty( $links ) ) {
+                       $response->add_links( $links );
+               }
 
-		return $response;
-	}
+               /**
+                * Filter the REST response for a feature.
+                *
+                * @since 0.1.0
+                * @param WP_REST_Response $response The response object.
+                * @param WP_Feature       $feature  The feature object.
+                */
+               $response = apply_filters( 'wp_feature_rest_response', $response, $feature );
+
+               return $response;
+       }
 
 	/**
 	 * Retrieves the query params for collections.

--- a/phpunit/tests/class-versioning-test.php
+++ b/phpunit/tests/class-versioning-test.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Versioning Helper Tests.
+ *
+ * @package WordPress\Features_API
+ */
+class WP_Versioning_Test extends WP_UnitTestCase {
+    public function test_is_deprecated_returns_true_when_version_after_deprecated() {
+        $feature = new WP_Feature( 'test/deprecated', array(
+            'name' => 'Test',
+            'description' => 'desc',
+            'version' => '2.0.0',
+            'deprecated_version' => '1.0.0',
+        ) );
+
+        $this->assertTrue( $feature->is_deprecated() );
+    }
+
+    public function test_get_alternatives_returns_value() {
+        $feature = new WP_Feature( 'test/alt', array(
+            'name' => 'Test',
+            'description' => 'desc',
+            'alternatives' => array( 'other/feature' ),
+        ) );
+
+        $this->assertSame( array( 'other/feature' ), $feature->get_alternatives() );
+    }
+
+    public function test_deprecated_hooks_fire_and_filter_blocks_execution() {
+        $feature = new WP_Feature( 'test/hook', array(
+            'name' => 'Test',
+            'description' => 'desc',
+            'version' => '2.0.0',
+            'deprecated_version' => '1.0.0',
+            'callback' => function() {
+                return 'ran';
+            },
+        ) );
+
+        $triggered = 0;
+        add_action( 'wp_feature_deprecated_run', function() use ( &$triggered ) {
+            $triggered++;
+        }, 10, 4 );
+
+        add_filter( 'wp_feature_handle_deprecated', '__return_false', 10, 3 );
+
+        $request = new WP_REST_Request( 'POST', '/test' );
+        $result  = $feature->call( $request );
+
+        remove_filter( 'wp_feature_handle_deprecated', '__return_false', 10 );
+
+        $this->assertSame( 1, $triggered );
+        $this->assertWPError( $result );
+    }
+}


### PR DESCRIPTION
## Summary
- rename deprecated helpers to snake_case
- document `wp_feature_handle_deprecated` filter
- add docs explaining feature versioning and hooks
- include PHPUnit tests for versioning helpers

## Testing
- `npm run lint:js` *(fails: `wp-scripts: not found`)*
- `npm run test:unit:php:base` *(fails: `wp-env: not found`)*