### PR TITLE
Fix license references to `GPL-2.0-or-later`

### DIFF
--- a/demo/wp-feature-api-agent/wp-feature-api-agent.php
+++ b/demo/wp-feature-api-agent/wp-feature-api-agent.php
@@ -7,8 +7,8 @@
  * Author: WordPress Contributors
  * Author URI: https://wordpress.org/
  * Text Domain: wp-feature-api-agent
- * License: GPL-2.0+
- * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+ * License: GPL-2.0-or-later
+ * License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
  * Requires at least: 6.0
  * Requires PHP: 7.4
  *

--- a/wp-feature-api.php
+++ b/wp-feature-api.php
@@ -7,8 +7,8 @@
  * Author: Automattic AI
  * Author URI: https://automattic.ai/
  * Text Domain: wp-feature-api
- * License: GPL-2.0+
- * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+ * License: GPL-2.0-or-later
+ * License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
  *
  * @package WordPress\Feature_API
  */


### PR DESCRIPTION
This pull request updates the license information in two files to use the more precise `GPL-2.0-or-later` license identifier and its corresponding SPDX URL.  This matches what's more precisely referenced in [composer.json](https://github.com/Automattic/wp-feature-api/blob/b3158d6bbe2f45833c7454ca9147d369ff3fec6b/composer.json#L5) and [package.json](https://github.com/Automattic/wp-feature-api/blob/b3158d6bbe2f45833c7454ca9147d369ff3fec6b/package.json#L41) [files](https://github.com/Automattic/wp-feature-api/blob/b3158d6bbe2f45833c7454ca9147d369ff3fec6b/packages/client/package.json#L38).

License updates:

* Updated the license in `demo/wp-feature-api-agent/wp-feature-api-agent.php` to `GPL-2.0-or-later` and replaced the license URI with the SPDX URL for better clarity and compliance.
* Updated the license in `wp-feature-api.php` to `GPL-2.0-or-later` and replaced the license URI with the SPDX URL for consistency with modern licensing practices.

Note that I held off on creating a `LICENSE.md` file at the root level, but that's also something to consider alongside these updates.