### PR TITLE
Fetch all available features from the API endpoint.

### DIFF
--- a/packages/client/src/store/resolvers.ts
+++ b/packages/client/src/store/resolvers.ts
@@ -12,10 +12,29 @@ import { store } from './index';
 
 export function getRegisteredFeatures() {
 	return async ( { dispatch, registry } ) => {
-		const features = await registry
-			.resolveSelect( coreStore )
-			.getEntityRecords( ENTITY_KIND, ENTITY_NAME );
-		dispatch( receiveFeatures( features ) );
+		// Start with page 1
+		let page = 1;
+		let allFeatures = [];
+		let hasMore = true;
+
+		// Keep fetching pages until we have all features
+		while ( hasMore ) {
+			const features = await registry
+				.resolveSelect( coreStore )
+				.getEntityRecords( ENTITY_KIND, ENTITY_NAME, {
+					page,
+					per_page: 100,
+				} );
+			
+			if ( ! features || features.length === 0 ) {
+				hasMore = false;
+			} else {
+				allFeatures = [ ...allFeatures, ...features ];
+				page++;
+			}
+		}
+
+		dispatch( receiveFeatures( allFeatures ) );
 	};
 }
 


### PR DESCRIPTION
### The What
As `/wp/v2/features` endpoint defaults to 10 features per request, if there were more features/tools, the rest of them weren't available. This PR addresses this problem in 2 ways:
- extends `per_page` to 100 to reduce the number of requests needed to get all features
- iterates through pages until there are no more pages/features returned 

### The How
I tried to make it work using `getEntityRecordsTotalItems`, which would allow one fewer request and parallel fetch of subsequent requests, but it always returned that there's only 1 page of results, so sticking to the while loop for now. Otherwise this would have to be switched to manual fetch.
