### PR TITLE
Add a check before requiring the assets file.

### DIFF
--- a/includes/class-wp-feature-api-init.php
+++ b/includes/class-wp-feature-api-init.php
@@ -41,8 +41,16 @@ class WP_Feature_API_Init {
 		if ( ! is_admin() ) {
 			return;
 		}
+
+		if ( ! file_exists( WP_FEATURE_API_PLUGIN_DIR . 'build/index.asset.php' ) ) {
+			if ( WP_DEBUG ) {
+				wp_trigger_error( '', 'Assets file not found, please run the build for the Feature API plugin.' );
+			}
+			return;
+		}
 		$assets = require WP_FEATURE_API_PLUGIN_DIR . 'build/index.asset.php';
 		wp_enqueue_script( 'wp-features', WP_FEATURE_API_PLUGIN_URL . 'build/index.js', $assets['dependencies'], $assets['version'], true );
+
 	}
 
 	/**

--- a/includes/class-wp-feature-api-init.php
+++ b/includes/class-wp-feature-api-init.php
@@ -41,7 +41,7 @@ class WP_Feature_API_Init {
 		if ( ! is_admin() ) {
 			return;
 		}
-
+		// Check for the file before requiring it.
 		if ( ! file_exists( WP_FEATURE_API_PLUGIN_DIR . 'build/index.asset.php' ) ) {
 			if ( WP_DEBUG ) {
 				wp_trigger_error( '', 'Assets file not found, please run the build for the Feature API plugin.' );

--- a/includes/class-wp-feature-api-init.php
+++ b/includes/class-wp-feature-api-init.php
@@ -44,7 +44,7 @@ class WP_Feature_API_Init {
 		// Check for the file before requiring it.
 		if ( ! file_exists( WP_FEATURE_API_PLUGIN_DIR . 'build/index.asset.php' ) ) {
 			if ( WP_DEBUG ) {
-				wp_trigger_error( '', 'Assets file not found, please run the build for the Feature API plugin.' );
+				wp_trigger_error( '', 'Assets file not found, please run the build for the WordPress Feature API plugin.' );
 			}
 			return;
 		}


### PR DESCRIPTION
After checking out the repo and running `npm i && npm run setup`. I enabled the plugin and got a fatal error because the required `index.asset.php` did not exist. 

Running `npm run build` solved the problem but I think having a check before requiring the file is safer.

This PR check to see if the `file_exists` before requiring and additionally triggers an error that is output to the `debug.log` file if the `WP_DEBUG` constant is set.
