### PR TITLE
Update examples to include schemas

### DIFF
--- a/docs/3.registering-features.md
+++ b/docs/3.registering-features.md
@@ -1,6 +1,6 @@
 ### 3. Registering Features (`wp_register_feature`)
 
-The primary way to add functionality to the Feature API is by using the `wp_register_feature()` function, typically hooked into WordPress's `init` action.
+The primary way to add functionality to the Feature API is by using the `wp_register_feature()` function, typically hooked into the `wp_feature_api_init` action.
 
 **Function Signature**
 
@@ -8,42 +8,42 @@ The primary way to add functionality to the Feature API is by using the `wp_regi
 wp_register_feature( array|WP_Feature $feature_args ): bool
 ```
 
-*   `$feature_args` (`array`|`WP_Feature`): An array of arguments defining the feature, or an instance of the `WP_Feature` class.
-*   **Return:** (`bool`) `true` if the feature was successfully registered, `false` on failure (e.g., invalid arguments, duplicate ID).
+-   `$feature_args` (`array`|`WP_Feature`): An array of arguments defining the feature, or an instance of the `WP_Feature` class.
+-   **Return:** (`bool`) `true` if the feature was successfully registered, `false` on failure (e.g., invalid arguments, duplicate ID).
 
 **Parameters Explained**
 
 The `$feature_args` array accepts the following keys (corresponding to `WP_Feature` properties):
 
-*   `id` (`string`, **Required**): A unique identifier for the feature.
-    *   **Convention:** Use a namespace prefix, like `my-plugin/feature-name` or `woocommerce/get-product`.
-    *   **Format:** Must contain only lowercase alphanumeric characters (`a-z`, `0-9`), hyphens (`-`), and forward slashes (`/`) for namespacing. Cannot start or end with `/`, and cannot contain `//`.
-    *   **Note:** The `type` prefix (e.g., `resource-`, `tool-`) is added *automatically* when retrieving the full feature ID via `$feature->get_id()` or when finding features. You register it *without* the type prefix.
-*   `name` (`string`, **Required**): A human-readable name for the feature. Used for display purposes. Should be translatable.
-*   `description` (`string`, **Required**): A detailed description of what the feature does, its purpose, and potentially its parameters or return values. This is crucial for AI agents to understand how and when to use the feature. Should be translatable.
-*   `type` (`string`, **Required**): The type of feature. Must be one of:
-    *   `WP_Feature::TYPE_RESOURCE` ('resource'): For retrieving data (read-only). Maps to `GET` in REST.
-    *   `WP_Feature::TYPE_TOOL` ('tool'): For performing actions or modifying data. Maps to `POST`, `PUT`, `PATCH`, `DELETE` in REST.
-*   `callback` (`callable`|`null`): The PHP function or method to execute when this feature is called via `$feature->call()`.
-    *   If `null` or not provided, calling the feature might not do anything unless it's a `rest_alias`.
-    *   The callback receives one argument: `$context` (an associative array of input parameters).
-    *   The callback should return the result of the feature's operation or a `WP_Error` object on failure.
-*   `input_schema` (`array`): A JSON Schema definition describing the expected input parameters (`$context`) for the `callback`. Used for validation and documentation. Defaults to an empty array.
-*   `output_schema` (`array`): A JSON Schema definition describing the expected format of the data returned by the `callback`. Used for validation and documentation. Defaults to an empty array.
-*   `permission_callback` (`callable`|`null`): A callback function to check if the current user has permission to execute this feature.
-    *   Should return `true` if the user has permission, `false` or a `WP_Error` object otherwise.
-    *   Defaults to a callback that returns `false` if not specified. Use `__return_true` for publicly accessible features (respecting underlying WP capabilities if applicable).
-    *   For `rest_alias` features, this often defaults to the permission callback of the aliased REST endpoint.
-*   `is_eligible` (`callable`|`null`): A callback function to determine if the feature is available in the current context.
-    *   Should return `true` if the feature is eligible, `false` otherwise.
-    *   Useful for features that depend on other plugins being active, specific user roles, or particular site settings.
-    *   Defaults to a callback that returns `true` (always eligible) if not specified.
-*   `categories` (`string[]`): An array of category slugs to associate with the feature. Helps organize and filter features. Categories are created implicitly if they don't exist.
-*   `meta` (`array`): An associative array for storing arbitrary additional metadata about the feature.
-*   `rest_alias` (`string`|`false`): If set to a string representing a WordPress REST API route (e.g., `/wp/v2/posts/(?P<id>[\d]+)`), this feature will act as an alias for that endpoint.
-    *   When `call()` is invoked, the Feature API will attempt to map the input context to the REST route parameters and execute the corresponding REST API request.
-    *   The `input_schema`, `output_schema`, `permission_callback`, and sometimes the `callback` might be automatically inferred from the REST endpoint definition. You can still override them explicitly.
-    *   Defaults to `false`.
+-   `id` (`string`, **Required**): A unique identifier for the feature.
+    -   **Convention:** Use a namespace prefix, like `my-plugin/feature-name` or `woocommerce/get-product`.
+    -   **Format:** Must contain only lowercase alphanumeric characters (`a-z`, `0-9`), hyphens (`-`), and forward slashes (`/`) for namespacing. Cannot start or end with `/`, and cannot contain `//`.
+    -   **Note:** The `type` prefix (e.g., `resource-`, `tool-`) is added _automatically_ when retrieving the full feature ID via `$feature->get_id()` or when finding features. You register it _without_ the type prefix.
+-   `name` (`string`, **Required**): A human-readable name for the feature. Used for display purposes. Should be translatable.
+-   `description` (`string`, **Required**): A detailed description of what the feature does, its purpose, and potentially its parameters or return values. This is crucial for AI agents to understand how and when to use the feature. Should be translatable.
+-   `type` (`string`, **Required**): The type of feature. Must be one of:
+    -   `WP_Feature::TYPE_RESOURCE` ('resource'): For retrieving data (read-only). Maps to `GET` in REST.
+    -   `WP_Feature::TYPE_TOOL` ('tool'): For performing actions or modifying data. Maps to `POST`, `PUT`, `PATCH`, `DELETE` in REST.
+-   `callback` (`callable`|`null`): The PHP function or method to execute when this feature is called via `$feature->call()`.
+    -   If `null` or not provided, calling the feature might not do anything unless it's a `rest_alias`.
+    -   The callback receives one argument: `$context` (an associative array of input parameters).
+    -   The callback should return the result of the feature's operation or a `WP_Error` object on failure.
+-   `input_schema` (`array`): A JSON Schema definition describing the expected input parameters (`$context`) for the `callback`. Used for validation and documentation. Defaults to an empty array.
+-   `output_schema` (`array`): A JSON Schema definition describing the expected format of the data returned by the `callback`. Used for validation and documentation. Defaults to an empty array.
+-   `permission_callback` (`callable`|`null`): A callback function to check if the current user has permission to execute this feature.
+    -   Should return `true` if the user has permission, `false` or a `WP_Error` object otherwise.
+    -   Defaults to a callback that returns `false` if not specified. Use `__return_true` for publicly accessible features (respecting underlying WP capabilities if applicable).
+    -   For `rest_alias` features, this often defaults to the permission callback of the aliased REST endpoint.
+-   `is_eligible` (`callable`|`null`): A callback function to determine if the feature is available in the current context.
+    -   Should return `true` if the feature is eligible, `false` otherwise.
+    -   Useful for features that depend on other plugins being active, specific user roles, or particular site settings.
+    -   Defaults to a callback that returns `true` (always eligible) if not specified.
+-   `categories` (`string[]`): An array of category slugs to associate with the feature. Helps organize and filter features. Categories are created implicitly if they don't exist.
+-   `meta` (`array`): An associative array for storing arbitrary additional metadata about the feature.
+-   `rest_alias` (`string`|`false`): If set to a string representing a WordPress REST API route (e.g., `/wp/v2/posts/(?P<id>[\d]+)`), this feature will act as an alias for that endpoint.
+    -   When `call()` is invoked, the Feature API will attempt to map the input context to the REST route parameters and execute the corresponding REST API request.
+    -   The `input_schema`, `output_schema`, `permission_callback`, and sometimes the `callback` might be automatically inferred from the REST endpoint definition. You can still override them explicitly.
+    -   Defaults to `false`.
 
 **Code Examples**
 
@@ -61,6 +61,10 @@ wp_register_feature( array(
     'type'        => WP_Feature::TYPE_RESOURCE,
     'categories'  => array( 'my-plugin', 'site-info' ),
     'permission_callback' => '__return_true',
+	'input_schema' => array(
+		'type' => 'object',
+	),
+	'output_schema' => array(),
 ) );
 ```
 
@@ -79,6 +83,9 @@ wp_register_feature( array(
     'type'        => WP_Feature::TYPE_RESOURCE,
     'callback'    => 'myplugin_get_active_theme_name',
     'permission_callback' => '__return_true',
+	'input_schema' => array(
+		'type' => 'object'
+	),
     'output_schema' => array(
         'type' => 'string',
         'description' => __( 'The name of the active theme.', 'my-plugin' ),


### PR DESCRIPTION
Using the current examples as is in a plugin will fire fatals. This PR addresses that by adding the `input_schema` and `output_schema` properties to the PHP examples.