### PR TITLE
Move wp_feature_api_init do_action to avoid fatals

### DIFF
--- a/includes/class-wp-feature-api-init.php
+++ b/includes/class-wp-feature-api-init.php
@@ -51,9 +51,10 @@ class WP_Feature_API_Init {
 	 */
 	public static function register_rest_routes() {
 		$controller = new WP_REST_Feature_Controller();
-		$controller->register_routes();
 
 		do_action( 'wp_feature_api_init' );
+
+		$controller->register_routes();
 	}
 
 	/**

--- a/includes/class-wp-feature-api-init.php
+++ b/includes/class-wp-feature-api-init.php
@@ -27,8 +27,6 @@ class WP_Feature_API_Init {
 		if ( defined( 'WP_FEATURE_API_LOAD_DEMO' ) && WP_FEATURE_API_LOAD_DEMO ) {
 			self::load_agent_demo();
 		}
-
-		do_action( 'wp_feature_api_init' );
 	}
 
 	/**
@@ -54,6 +52,8 @@ class WP_Feature_API_Init {
 	public static function register_rest_routes() {
 		$controller = new WP_REST_Feature_Controller();
 		$controller->register_routes();
+
+		do_action( 'wp_feature_api_init' );
 	}
 
 	/**


### PR DESCRIPTION
Closes #74. 