### PR TITLE
Release 0.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Manually adding to your `composer.json` file:
 ```json
 {
   "require": {
-    "automattic/wp-feature-api": "^0.1.5" // Make sure to use the latest version
+    "automattic/wp-feature-api": "^0.1.6" // Make sure to use the latest version
   }
 }
 ```
@@ -74,7 +74,7 @@ Manually adding to your `composer.json` file:
 If using the `composer` command in the terminal:
 
 ```bash
-composer require automattic/wp-feature-api:"^0.1.5"
+composer require automattic/wp-feature-api:"^0.1.6"
 ```
 
 #### 2. Load the Feature API in your plugin

--- a/demo/wp-feature-api-agent/wp-feature-api-agent.php
+++ b/demo/wp-feature-api-agent/wp-feature-api-agent.php
@@ -32,24 +32,15 @@ require_once WP_AI_API_PROXY_PATH . 'includes/class-wp-ai-api-options.php';
 // Include the feature registration class.
 require_once WP_AI_API_PROXY_PATH . 'includes/class-wp-feature-register.php';
 
-/**
- * Initializes the plugin.
- *
- * Loads the plugin's main class and registers hooks.
- */
-function wp_ai_api_proxy_init() {
-	$proxy_instance = new A8C\WpFeatureApiAgent\WP_AI_API_Proxy();
-	$proxy_instance->register_hooks();
+$proxy_instance = new A8C\WpFeatureApiAgent\WP_AI_API_Proxy();
+$proxy_instance->register_hooks();
 
-	$options_instance = new A8C\WpFeatureApiAgent\WP_AI_API_Options();
-	$options_instance->init();
+$options_instance = new A8C\WpFeatureApiAgent\WP_AI_API_Options();
+$options_instance->init();
 
-	// Register additional demo features.
-	$feature_register_instance = new A8C\WpFeatureApiAgent\WP_Feature_Register();
-	$feature_register_instance->init();
-}
-
-add_action( 'wp_feature_api_init', 'wp_ai_api_proxy_init' );
+// Register additional demo features.
+$feature_register_instance = new A8C\WpFeatureApiAgent\WP_Feature_Register();
+$feature_register_instance->init();
 
 /**
  * Enqueues scripts and styles for the admin area.

--- a/docs/2.getting-started.md
+++ b/docs/2.getting-started.md
@@ -11,7 +11,7 @@ This is the recommended approach for plugin developers to include the WordPress 
    ```json
    {
      "require": {
-       "automattic/wp-feature-api": "^0.1.5" // Make sure you are using the latest version!
+       "automattic/wp-feature-api": "^0.1.6" // Make sure you are using the latest version!
      }
    }
    ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-feature-api",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "A system for exposing WordPress functionality in a standardized, discoverable way for both server and client-side use",
 	"main": "src/index.js",
 	"private": true,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/wp-feature-api",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Client-side SDK for WordPress Feature API",
   "main": "build/index.js",
   "types": "build-types/index.d.ts",

--- a/wp-feature-api.php
+++ b/wp-feature-api.php
@@ -3,7 +3,7 @@
  * Plugin Name: WordPress Feature API
  * Plugin URI: https://github.com/Automattic/wp-feature-api
  * Description: A system for exposing server and client-side functionality in WordPress for use in LLMs and agentic systems.
- * Version: 0.1.5
+ * Version: 0.1.6
  * Author: Automattic AI
  * Author URI: https://automattic.ai/
  * Text Domain: wp-feature-api
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$wp_feature_api_version = '0.1.5';
+$wp_feature_api_version = '0.1.6';
 $wp_feature_api_plugin_dir = plugin_dir_path( __FILE__ );
 $wp_feature_api_plugin_url = plugin_dir_url( __FILE__ );
 


### PR DESCRIPTION
This PR preps 0.1..

It also fixes an issue with the demo agent. With the `wp_feature_api_init` hook getting moved, things in the demo agent were getting registered too late. None of the classes getting registered needed to wait for `wp_feature_api_init` though.