### PR TITLE
Rethinking of when features are initialized.

### DIFF
--- a/demo/wp-feature-api-agent/includes/class-wp-feature-register.php
+++ b/demo/wp-feature-api-agent/includes/class-wp-feature-register.php
@@ -15,14 +15,6 @@ use WP_Feature;
 class WP_Feature_Register {
 
 	/**
-	 * Registers WordPress hooks.
-	 */
-	public function init() {
-		// Register features immediately - we're already in the wp_feature_api_init action
-		$this->register_features();
-	}
-
-	/**
 	 * Register features for the AI Agent.
 	 *
 	 * @since 0.1.0

--- a/demo/wp-feature-api-agent/wp-feature-api-agent.php
+++ b/demo/wp-feature-api-agent/wp-feature-api-agent.php
@@ -40,7 +40,7 @@ $options_instance->init();
 
 // Register additional demo features.
 $feature_register_instance = new A8C\WpFeatureApiAgent\WP_Feature_Register();
-$feature_register_instance->init();
+add_action( 'wp_feature_api_init', array( $feature_register_instance, 'register_features' ) );
 
 /**
  * Enqueues scripts and styles for the admin area.

--- a/includes/class-wp-feature-api-init.php
+++ b/includes/class-wp-feature-api-init.php
@@ -19,7 +19,7 @@ class WP_Feature_API_Init {
 	public static function initialize() {
 
 		// Run the wp_feature_api_init action after the regular REST routes are registered.
-		add_action( 'rest_api_init', array( __CLASS__, 'run_init_action' ), 100 );
+		add_action( 'rest_api_init', array( __CLASS__, 'run_init_action' ), 110 );
 		add_action( 'parse_request', array( __CLASS__, 'run_init_action' ), 11 );
 
 		// Register REST routes after the regular REST routes are registered

--- a/includes/class-wp-feature-api-init.php
+++ b/includes/class-wp-feature-api-init.php
@@ -19,13 +19,14 @@ class WP_Feature_API_Init {
 	public static function initialize() {
 
 		// Run the wp_feature_api_init action after the regular REST routes are registered.
+		add_action( 'rest_api_init', array( __CLASS__, 'run_init_action' ), 100 );
 		add_action( 'parse_request', array( __CLASS__, 'run_init_action' ), 11 );
 
 		// Register REST routes after the regular REST routes are registered
 		// (at rest_api_init:99 action which is triggered by parse_request:10 action).
 		// This ensures that the Feature API won't trigger creating the global WP rest api server
 		// too early (during the `init` action).
-		add_action( 'parse_request', array( __CLASS__, 'register_rest_routes' ), 20 );
+		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ), 120 );
 
 		// enqueue admin scripts.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_scripts' ) );
@@ -65,7 +66,12 @@ class WP_Feature_API_Init {
 	 * @return void
 	 */
 	public static function run_init_action() {
-		do_action( 'wp_feature_api_init' );
+		static $has_run = false;
+
+		if ( ! $has_run ) {
+			$has_run = true;
+			do_action( 'wp_feature_api_init' );
+		}
 	}
 
 	/**
@@ -75,10 +81,6 @@ class WP_Feature_API_Init {
 	 * @return void
 	 */
 	public static function register_rest_routes() {
-		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
-			return;
-		}
-
 		$controller = new WP_REST_Feature_Controller();
 		$controller->register_routes();
 	}

--- a/includes/class-wp-feature-api-init.php
+++ b/includes/class-wp-feature-api-init.php
@@ -17,8 +17,15 @@ class WP_Feature_API_Init {
 	 * @return void
 	 */
 	public static function initialize() {
-		// Register REST routes on init. Late execution to ensure features are registered by plugins first.
-		add_action( 'init', array( __CLASS__, 'register_rest_routes' ), 9999 );
+
+		// Run the wp_feature_api_init action after the regular REST routes are registered.
+		add_action( 'parse_request', array( __CLASS__, 'run_init_action' ), 11 );
+
+		// Register REST routes after the regular REST routes are registered
+		// (at rest_api_init:99 action which is triggered by parse_request:10 action).
+		// This ensures that the Feature API won't trigger creating the global WP rest api server
+		// too early (during the `init` action).
+		add_action( 'parse_request', array( __CLASS__, 'register_rest_routes' ), 20 );
 
 		// enqueue admin scripts.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_scripts' ) );
@@ -52,16 +59,27 @@ class WP_Feature_API_Init {
 	}
 
 	/**
+	 * Runs the wp_feature_api_init action.
+	 *
+	 * @since 0.1.0
+	 * @return void
+	 */
+	public static function run_init_action() {
+		do_action( 'wp_feature_api_init' );
+	}
+
+	/**
 	 * Registers the REST API routes for the Feature API.
 	 *
 	 * @since 0.1.0
 	 * @return void
 	 */
 	public static function register_rest_routes() {
+		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+			return;
+		}
+
 		$controller = new WP_REST_Feature_Controller();
-
-		do_action( 'wp_feature_api_init' );
-
 		$controller->register_routes();
 	}
 

--- a/includes/default-wp-features.php
+++ b/includes/default-wp-features.php
@@ -131,4 +131,4 @@ function wp_feature_api_register_core_features() {
 }
 
 // Register core features on init.
-add_action( 'init', 'wp_feature_api_register_core_features' );
+add_action( 'wp_feature_api_init', 'wp_feature_api_register_core_features' );


### PR DESCRIPTION
## The What & Why

This PR is based on [my observations during the investigation of the timing issue](https://github.com/Automattic/wp-feature-api/issues/80#issuecomment-3006131398) of initialization in our plugin using the WP Feature API.

Essentially, I'm proposing that **it makes sense to use the existing REST API for feature discovery**, and thus also to decide which features are available based on REST API structure.

As an example, in our plugin, WooCommerce, 3rd party plugins can add their own functionality. Ideally, this functionality would be exposed via REST API either as custom endpoints or extensions to the existing Woo endpoints. 

To allow easy discovery of the availability of the plugin functionality and also of (general, non-WP Feature API) [features enabled in Woo](https://woocommerce.com/document/configuring-woocommerce-settings/advanced/#features) itself, I think it makes sense to support registering features later than on `init`, because REST API routes are usually registered later during `rest_api_init`. This is currently not possible as `wp_feature_api_init ` (and thus normally also registering of WP Feature API features) happens too early.

Normal WP timeline (without WP Feature API):

1. `init` starts
2. `init:9999` (WP Feature API executes `wp_feature_api_init` here currently, if it's active)
3. `init` ends
4. `parse_request` starts
5. `parse_request:10` calls`rest_api_init`, if it's a REST API request
6. Most default routes are registered during `rest_api_init:99` via `create_initial_rest_routes`

The way things currently work, this plugin forces `rest_api_init` at `init:10` by calling `wp_feature_api_register_core_features`.

I suggest **we move the `wp_feature_api_init` to a later phase**: 
- `parse_request:11`, i.e. after the timeline listed above completes, if the current request isn't a REST API request. 
- `rest_api_init:100`, if it is a REST API request, so that `register_rest_routes` can be called after features are registered, but still during `rest_api_init` so that the REST endpoints are registered correctly for WP Feature API.

I also suggest that **most PHP features should be registered at `wp_feature_api_init`**. I don't see a reason why we would require them to be registered early at the moment.

This way, plugins using WP Feature API can use the shape of REST API as an indicator of what features to register. I think it makes sense also from the perspective of this plugin relying on REST API quite heavily.

Another change introduced here is to execute `WP_Feature_API_Init::register_rest_routes` only after the main REST API endpoints are registered, not before (currently it's executed at init:9999). This triggers `register_rest_route` very early during `init` and that function can only be called after `rest_api_init`, so I think it makes sense to move it to a later stage, too. (The reason why this didn't bomb right now is that `wp_feature_api_register_core_features` triggered the `rest_api_init` during `init:10`.

The timeline with WP Feature API is currently as follows:

1. `init` starts
2. `init:10`: WP Feature API calls `wp_feature_api_register_core_features` [here](https://github.com/Automattic/wp-feature-api/blob/trunk/includes/default-wp-features.php#L134)
3. This triggers `rest_get_server()` from `WP_Feature::make` via `WP_Feature::get_rest_alias`, which executes `rest_api_init` action.
4. `init:9999` executes `wp_feature_api_init` and `WP_Feature_API_Init::register_rest_routes`
5. `init` ends
6. `parse_request`
7.  `rest_api_init` is **NOT** executed, because it's only executed if the global rest_server object doesn't already exist

This, I believe, is also **bad for performance**, as all the REST API init moves to step 2-3 from step 6, and it's executed even when this is not a REST API request.

For an opposing point of view, perhaps those 3rd party extensions should register their own features, and it shouldn't matter when the registering happens. It feels we're giving up some of the flexibility we have and our ability to build something that automatically supports a wider set of features if we opt for that approach.

Alternatively, other users of WP Feature API can hook their feature registration to another action, but I think it will create confusion if `wp_feature_api_init` works the way it does right now.

Demonstration that the proposed code runs correctly with the demo app:
<img width="1727" alt="Screenshot 2025-06-27 at 13 26 53" src="https://github.com/user-attachments/assets/46d085f1-7afa-4052-8a43-f931420752e3" />

Closes https://linear.app/a8c/issue/AI-310/improve-the-initialization-sequence

## How to test this

1. Check that the demo features work
2. Try to build a small plugin that registers features during different parts of WP lifecycle, e.g. when the plugin is loaded by WP, during `init`, `plugins_loaded`, `wp_feature_api_init`.
3. Check that all the features work fine, e.g. they are listed via `/wp-json/wp/v2/features` or can be executed via `/wp-json/wp/v2/features/feature-id/run`

