### PR TITLE
Made the schema reflect the endpoint behavior.

### DIFF
--- a/includes/rest-api/class-wp-rest-feature-controller.php
+++ b/includes/rest-api/class-wp-rest-feature-controller.php
@@ -498,20 +498,9 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 						return rest_ensure_response( $result );
 					},
 					'permission_callback' => array( $feature, 'get_permission_callback' ),
-					'args'                => array(
-						'metadata' => array(
-							'description' => __( 'Metadata for executing the feature.', 'wp-feature-api' ),
-							'type'        => 'object',
-							'properties'  => array(
-								'client_features' => array(
-									'type'        => 'array',
-									'items'       => $this->get_item_schema(),
-								),
-							),
-						),
-					),
+					'args'                => $feature->get_input_schema(),
 				),
-				'schema' => array( $feature, 'get_item_schema' ),
+				'schema' => array( $feature, 'get_output_schema' ),
 			)
 		);
 
@@ -528,7 +517,7 @@ class WP_REST_Feature_Controller extends WP_REST_Controller {
 					},
 					'permission_callback' => array( $feature, 'get_permission_callback' ),
 				),
-				'schema' => array( $feature, 'get_output_schema' ),
+				'schema' => array( $this, 'get_item_schema' ),
 			)
 		);
 	}


### PR DESCRIPTION
## The What

This change 
- Prevents fatal errors when checking the schema of registered features
- Improves the descriptions/schemas of the registered endpoints

Closes https://linear.app/a8c/issue/AI-311/fix-feature-registration-schema-related-problems

### wp/v2/feature/feature_id/run Endpoint
`WP_Feature` class doesn't have `get_item_schema` method, and probably shouldn't have that method either. Since the callback is executed directly when the endpoint is called, the schema should describe the output given by the callback, i.e. the `output_schema` from the feature API definition.

Similarly, the args needed to execute the feature call aren't described in the generic feature description, but via the `WP_Feature::get_input_schema`.

### wp/v2/feature/feature_id Endpoint
This endpoint returns information about the registered feature. Thus, using the `output_schema` as schema for this endpoint isn't correct.


## How To Test
1. Start with `trunk`
2. Create a feature with input and output schemas. 
3. Try to get the schema for both endpoints, e.g. via:
    1.  curl -X OPTIONS 'https://example.com/wp-json/wp/v2/features/feature-id', and 
    2. curl -X OPTIONS 'https://example.com/wp-json/wp/v2/features/feature-id/run'
5. You should see the `run` endpoint trigger an error (`PHP Fatal error:  Uncaught TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, class WP_Feature does not have a method "get_item_schema" in .../wp-includes/rest-api/class-wp-rest-server.php:1631`).
6. Switch to this branch
7. The error should be gone, and the schemas should now be 'more correct'.
