### PR TITLE
Bump version to 0.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Manually adding to your `composer.json` file:
 ```json
 {
   "require": {
-    "automattic/wp-feature-api": "^0.1.6" // Make sure to use the latest version
+    "automattic/wp-feature-api": "^0.1.7" // Make sure to use the latest version
   }
 }
 ```
@@ -74,7 +74,7 @@ Manually adding to your `composer.json` file:
 If using the `composer` command in the terminal:
 
 ```bash
-composer require automattic/wp-feature-api:"^0.1.6"
+composer require automattic/wp-feature-api:"^0.1.7"
 ```
 
 #### 2. Load the Feature API in your plugin

--- a/docs/2.getting-started.md
+++ b/docs/2.getting-started.md
@@ -11,7 +11,7 @@ This is the recommended approach for plugin developers to include the WordPress 
    ```json
    {
      "require": {
-       "automattic/wp-feature-api": "^0.1.6" // Make sure you are using the latest version!
+       "automattic/wp-feature-api": "^0.1.7" // Make sure you are using the latest version!
      }
    }
    ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-feature-api",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"description": "A system for exposing WordPress functionality in a standardized, discoverable way for both server and client-side use",
 	"main": "src/index.js",
 	"private": true,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/wp-feature-api",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Client-side SDK for WordPress Feature API",
   "main": "build/index.js",
   "types": "build-types/index.d.ts",

--- a/wp-feature-api.php
+++ b/wp-feature-api.php
@@ -3,7 +3,7 @@
  * Plugin Name: WordPress Feature API
  * Plugin URI: https://github.com/Automattic/wp-feature-api
  * Description: A system for exposing server and client-side functionality in WordPress for use in LLMs and agentic systems.
- * Version: 0.1.6
+ * Version: 0.1.7
  * Author: Automattic AI
  * Author URI: https://automattic.ai/
  * Text Domain: wp-feature-api
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$wp_feature_api_version = '0.1.6';
+$wp_feature_api_version = '0.1.7';
 $wp_feature_api_plugin_dir = plugin_dir_path( __FILE__ );
 $wp_feature_api_plugin_url = plugin_dir_url( __FILE__ );
 


### PR DESCRIPTION
This PR preps version 0.1.7.

This release alters the initialization sequence of the plugin to postpone the feature registration timing to a later point (after REST API endpoints are registered).